### PR TITLE
Replace omega with lia

### DIFF
--- a/src/Rewriter/Util/ListUtil.v
+++ b/src/Rewriter/Util/ListUtil.v
@@ -1,6 +1,8 @@
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega Coq.micromega.Lia.
+Require Import Coq.micromega.Lia.
 Require Import Coq.Arith.Peano_dec.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Arith.Arith.
 Require Import Coq.Classes.Morphisms.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Rewriter.Util.NatUtil.
@@ -122,7 +124,7 @@ Hint Rewrite
 
 Hint Extern 1 => progress autorewrite with distr_length in * : distr_length.
 Ltac distr_length := autorewrite with distr_length in *;
-  try solve [simpl in *; omega].
+  try solve [simpl in *; lia].
 
 Module Export List.
   Local Set Implicit Arguments.
@@ -310,8 +312,8 @@ Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @
 Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : simpl_firstn.
 Hint Rewrite @firstn_app : push_firstn.
 Hint Rewrite <- @firstn_cons @firstn_app @List.firstn_firstn : pull_firstn.
-Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using omega : push_firstn.
-Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using omega : simpl_firstn.
+Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : push_firstn.
+Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : simpl_firstn.
 
 Local Arguments value / _ _.
 Local Arguments error / _.
@@ -422,7 +424,7 @@ Ltac nth_tac' :=
     | [ H: None = Some _  |- _ ] => inversion H
     | [ H: Some _ = None |- _ ] => inversion H
     | [ |- Some _ = Some _ ] => apply f_equal
-  end); eauto; try (autorewrite with list in *); try omega; eauto.
+  end); eauto; try (autorewrite with list in *); try lia; eauto.
 Lemma nth_error_map : forall A B (f:A->B) i xs y,
   nth_error (map f xs) i = Some y ->
   exists x, nth_error xs i = Some x /\ f x = y.
@@ -441,23 +443,23 @@ Qed.
 Lemma nth_error_error_length : forall A i (xs:list A), nth_error xs i = None ->
   i >= length xs.
 Proof.
-  induction i as [|? IHi]; destruct xs; nth_tac'; try match goal with H : _ |- _ => specialize (IHi _ H) end; omega.
+  induction i as [|? IHi]; destruct xs; nth_tac'; try match goal with H : _ |- _ => specialize (IHi _ H) end; lia.
 Qed.
 
 Lemma nth_error_value_length : forall A i (xs:list A) x, nth_error xs i = Some x ->
   i < length xs.
 Proof.
-  induction i as [|? IHi]; destruct xs; nth_tac'; try match goal with H : _ |- _ => specialize (IHi _ _ H) end; omega.
+  induction i as [|? IHi]; destruct xs; nth_tac'; try match goal with H : _ |- _ => specialize (IHi _ _ H) end; lia.
 Qed.
 
 Lemma nth_error_length_error : forall A i (xs:list A),
   i >= length xs ->
   nth_error xs i = None.
 Proof.
-  induction i as [|? IHi]; destruct xs; nth_tac'; rewrite IHi by omega; auto.
+  induction i as [|? IHi]; destruct xs; nth_tac'; rewrite IHi by lia; auto.
 Qed.
 Hint Resolve nth_error_length_error : core.
-Hint Rewrite @nth_error_length_error using omega : simpl_nth_error.
+Hint Rewrite @nth_error_length_error using lia : simpl_nth_error.
 
 Lemma map_nth_default : forall (A B : Type) (f : A -> B) n x y l,
   (n < length l) -> nth_default y (map f l) n = f (nth_default x l n).
@@ -469,10 +471,10 @@ Proof.
   nth_tac'.
   let H0 := match goal with H0 : _ = None |- _ => H0 end in
   pose proof (nth_error_error_length A n l H0).
-  omega.
+  lia.
 Qed.
 
-Hint Rewrite @map_nth_default using omega : push_nth_default.
+Hint Rewrite @map_nth_default using lia : push_nth_default.
 
 Ltac nth_tac :=
   repeat progress (try nth_tac'; try (match goal with
@@ -606,7 +608,7 @@ Hint Rewrite @length_set_nth : distr_length.
 Lemma nth_error_length_exists_value : forall {A} (i : nat) (xs : list A),
   (i < length xs)%nat -> exists x, nth_error xs i = Some x.
 Proof.
-  induction i, xs; boring; try omega.
+  induction i, xs; boring; try lia.
 Qed.
 
 Lemma nth_error_length_not_error : forall {A} (i : nat) (xs : list A),
@@ -643,7 +645,7 @@ Lemma splice_nth_equiv_update_nth : forall {T} n f d (xs:list T),
   then update_nth n f xs
   else xs ++ (f d)::nil.
 Proof.
-  induction n, xs; boring_list; break_match; auto; omega.
+  induction n, xs; boring_list; break_match; auto; lia.
 Qed.
 
 Lemma splice_nth_equiv_update_nth_update : forall {T} n f d (xs:list T),
@@ -651,7 +653,7 @@ Lemma splice_nth_equiv_update_nth_update : forall {T} n f d (xs:list T),
   splice_nth n (f (nth_default d xs n)) xs = update_nth n f xs.
 Proof.
   intros.
-  rewrite splice_nth_equiv_update_nth; break_match; auto; omega.
+  rewrite splice_nth_equiv_update_nth; break_match; auto; lia.
 Qed.
 
 Lemma splice_nth_equiv_update_nth_snoc : forall {T} n f d (xs:list T),
@@ -659,7 +661,7 @@ Lemma splice_nth_equiv_update_nth_snoc : forall {T} n f d (xs:list T),
   splice_nth n (f (nth_default d xs n)) xs = xs ++ (f d)::nil.
 Proof.
   intros.
-  rewrite splice_nth_equiv_update_nth; break_match; auto; omega.
+  rewrite splice_nth_equiv_update_nth; break_match; auto; lia.
 Qed.
 
 Definition IMPOSSIBLE {T} : list T. exact nil. Qed.
@@ -683,7 +685,7 @@ Proof.
   induction n as [|? IHn]; destruct xs; intros;
     autorewrite with simpl_update_nth simpl_nth_default in *; simpl in *;
       try (erewrite IHn; clear IHn); auto.
-  repeat break_match; remove_nth_error; try reflexivity; try omega.
+  repeat break_match; remove_nth_error; try reflexivity; try lia.
 Qed.
 
 Lemma splice_nth_equiv_set_nth : forall {T} n x (xs:list T),
@@ -763,7 +765,7 @@ Proof.
   nth_tac;
     [ repeat rewrite_rev_combine_update_nth; apply f_equal2
     | assert (nth_error (combine xs ys) n = None)
-      by (apply nth_error_None; rewrite combine_length; omega * ) ];
+      by (apply nth_error_None; rewrite combine_length; lia * ) ];
     autorewrite with simpl_update_nth; reflexivity.
 Qed.
 
@@ -794,7 +796,7 @@ Lemma nth_error_app : forall {T} n (xs ys:list T), nth_error (xs ++ ys) n =
   else nth_error ys (n - length xs).
 Proof.
   induction n as [|n IHn]; destruct xs as [|? xs]; nth_tac;
-    rewrite IHn; destruct (lt_dec n (length xs)); trivial; omega.
+    rewrite IHn; destruct (lt_dec n (length xs)); trivial; lia.
 Qed.
 
 Lemma nth_default_app : forall {T} n x (xs ys:list T), nth_default x (xs ++ ys) n =
@@ -826,7 +828,7 @@ Lemma combine_app_samelength : forall {A B} (xs xs':list A) (ys ys':list B),
   length xs = length ys ->
   combine (xs ++ xs') (ys ++ ys') = combine xs ys ++ combine xs' ys'.
 Proof.
-  induction xs, xs', ys, ys'; boring; omega.
+  induction xs, xs', ys, ys'; boring; lia.
 Qed.
 
 Lemma map_fst_combine {A B} (xs:list A) (ys:list B) : List.map fst (List.combine xs ys) = List.firstn (length ys) xs.
@@ -897,7 +899,7 @@ Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_skipn.
 Lemma firstn_app_inleft : forall {A} n (xs ys : list A), (n <= length xs)%nat ->
   firstn n (xs ++ ys) = firstn n xs.
 Proof.
-  induction n, xs, ys; boring; try omega.
+  induction n, xs, ys; boring; try lia.
 Qed.
 
 Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : simpl_firstn.
@@ -906,7 +908,7 @@ Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : push_firstn.
 Lemma skipn_app_inleft : forall {A} n (xs ys : list A), (n <= length xs)%nat ->
   skipn n (xs ++ ys) = skipn n xs ++ ys.
 Proof.
-  induction n, xs, ys; boring; try omega.
+  induction n, xs, ys; boring; try lia.
 Qed.
 
 Hint Rewrite @skipn_app_inleft using solve [ distr_length ] : push_skipn.
@@ -925,7 +927,7 @@ Hint Rewrite <- @skipn_map : pull_skipn.
 
 Lemma firstn_all : forall {A} n (xs:list A), n = length xs -> firstn n xs = xs.
 Proof.
-  induction n, xs; boring; omega.
+  induction n, xs; boring; lia.
 Qed.
 
 Hint Rewrite @firstn_all using solve [ distr_length ] : simpl_firstn.
@@ -935,7 +937,7 @@ Lemma skipn_all : forall {T} n (xs:list T),
   (n >= length xs)%nat ->
   skipn n xs = nil.
 Proof.
-  induction n, xs; boring; omega.
+  induction n, xs; boring; lia.
 Qed.
 
 Hint Rewrite @skipn_all using solve [ distr_length ] : simpl_skipn.
@@ -946,7 +948,7 @@ Lemma firstn_app_sharp : forall {A} n (l l': list A),
   firstn n (l ++ l') = l.
 Proof.
   intros.
-  rewrite firstn_app_inleft; auto using firstn_all; omega.
+  rewrite firstn_app_inleft; auto using firstn_all; lia.
 Qed.
 
 Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : simpl_firstn.
@@ -957,7 +959,7 @@ Lemma skipn_app_sharp : forall {A} n (l l': list A),
   skipn n (l ++ l') = l'.
 Proof.
   intros.
-  rewrite skipn_app_inleft; try rewrite skipn_all; auto; omega.
+  rewrite skipn_app_inleft; try rewrite skipn_all; auto; lia.
 Qed.
 
 Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : simpl_skipn.
@@ -992,7 +994,7 @@ Proof.
 Qed.
 
 Lemma length_tl {A} ls : length (@tl A ls) = (length ls - 1)%nat.
-Proof. destruct ls; cbn [tl length]; omega. Qed.
+Proof. destruct ls; cbn [tl length]; lia. Qed.
 Hint Rewrite @length_tl : distr_length.
 
 Lemma length_snoc : forall {T} xs (x:T),
@@ -1027,7 +1029,7 @@ Lemma combine_snoc {A B} xs : forall ys x y,
     @combine A B (xs ++ (x :: nil)) (ys ++ (y :: nil)) = combine xs ys ++ ((x, y) :: nil).
 Proof.
   induction xs; intros; destruct ys; distr_length; cbn;
-    try rewrite IHxs by omega; reflexivity.
+    try rewrite IHxs by lia; reflexivity.
 Qed.
 Hint Rewrite @combine_snoc using (solve [distr_length]) : push_combine.
 
@@ -1126,7 +1128,7 @@ Lemma skipn_nth_default : forall {T} n us (d : T), (n < length us)%nat ->
  skipn n us = nth_default d us n :: skipn (S n) us.
 Proof.
   induction n as [|n IHn]; destruct us as [|? us]; intros d H; nth_tac.
-  rewrite (IHn us d) at 1 by omega.
+  rewrite (IHn us d) at 1 by lia.
   nth_tac.
 Qed.
 
@@ -1136,14 +1138,14 @@ Proof.
   induction n as [|n IHn]; unfold nth_default; nth_tac;
     let us' := match goal with us : list _ |- _ => us end in
     destruct us' as [|? us]; nth_tac.
-  assert (n >= length us)%nat by omega.
+  assert (n >= length us)%nat by lia.
   pose proof (nth_error_length_error _ n us).
   specialize_by_assumption.
   rewrite_hyp * in *.
   congruence.
 Qed.
 
-Hint Rewrite @nth_default_out_of_bounds using omega : simpl_nth_default.
+Hint Rewrite @nth_default_out_of_bounds using lia : simpl_nth_default.
 
 Ltac nth_error_inbounds :=
   match goal with
@@ -1194,7 +1196,7 @@ Proof.
           | None => fun bad => match _ : False with end
           end eq_refl).
   apply (proj1 (@nth_error_None _ _ _)) in bad; instantiate; generalize dependent (length ls); clear.
-  abstract (intros; omega).
+  abstract (intros; lia).
 Defined.
 
 Lemma nth_error_nth_dep {A} ls n pf : nth_error ls n = Some (@nth_dep A ls n pf).
@@ -1257,8 +1259,8 @@ Lemma seq_len_0 a : seq a 0 = nil. Proof. reflexivity. Qed.
 Lemma seq_add start a b : seq start (a + b) = seq start a ++ seq (start + a) b.
 Proof.
   revert start b; induction a as [|a IHa]; cbn; intros start b.
-  { f_equal; omega. }
-  { rewrite IHa; do 3 f_equal; omega. }
+  { f_equal; lia. }
+  { rewrite IHa; do 3 f_equal; lia. }
 Qed.
 
 Lemma fold_right_and_True_forall_In_iff : forall {T} (l : list T) (P : T -> Prop),
@@ -1305,11 +1307,11 @@ Qed.
 Lemma firstn_firstn_min : forall {A} m n (l : list A),
     firstn n (firstn m l) = firstn (min n m) l.
 Proof.
-  induction m as [|? IHm]; destruct n; intros l; try omega; auto.
+  induction m as [|? IHm]; destruct n; intros l; try lia; auto.
   destruct l; auto.
   simpl.
   f_equal.
-  apply IHm; omega.
+  apply IHm; lia.
 Qed.
 
 Lemma firstn_firstn : forall {A} m n (l : list A), (n <= m)%nat ->
@@ -1317,19 +1319,19 @@ Lemma firstn_firstn : forall {A} m n (l : list A), (n <= m)%nat ->
 Proof.
   intros A m n l H; rewrite firstn_firstn_min.
   apply Min.min_case_strong; intro; [ reflexivity | ].
-  assert (n = m) by omega; subst; reflexivity.
+  assert (n = m) by lia; subst; reflexivity.
 Qed.
 
-Hint Rewrite @firstn_firstn using omega : push_firstn.
+Hint Rewrite @firstn_firstn using lia : push_firstn.
 
 Lemma firstn_succ : forall {A} (d : A) n l, (n < length l)%nat ->
   firstn (S n) l = (firstn n l) ++ nth_default d l n :: nil.
 Proof.
-  intros A d; induction n as [|? IHn]; destruct l; rewrite ?(@nil_length0 A); intros; try omega.
+  intros A d; induction n as [|? IHn]; destruct l; rewrite ?(@nil_length0 A); intros; try lia.
   + rewrite nth_default_cons; auto.
   + simpl.
     rewrite nth_default_cons_S.
-    rewrite <-IHn by (rewrite cons_length in *; omega).
+    rewrite <-IHn by (rewrite cons_length in *; lia).
     reflexivity.
 Qed.
 
@@ -1345,16 +1347,16 @@ Lemma skipn_seq k a b
   : skipn k (seq a b) = seq (k + a) (b - k).
 Proof.
   revert k a; induction b as [|? IHb], k; simpl; try reflexivity.
-  intros; rewrite IHb; simpl; f_equal; omega.
+  intros; rewrite IHb; simpl; f_equal; lia.
 Qed.
 
 Lemma update_nth_out_of_bounds : forall {A} n f xs, n >= length xs -> @update_nth A n f xs = xs.
 Proof.
-  induction n as [|n IHn]; destruct xs; simpl; try congruence; try omega; intros.
-  rewrite IHn by omega; reflexivity.
+  induction n as [|n IHn]; destruct xs; simpl; try congruence; try lia; intros.
+  rewrite IHn by lia; reflexivity.
 Qed.
 
-Hint Rewrite @update_nth_out_of_bounds using omega : simpl_update_nth.
+Hint Rewrite @update_nth_out_of_bounds using lia : simpl_update_nth.
 
 
 Lemma update_nth_nth_default_full : forall {A} (d:A) n f l i,
@@ -1364,13 +1366,13 @@ Lemma update_nth_nth_default_full : forall {A} (d:A) n f l i,
     else nth_default d l i
   else d.
 Proof.
-  induction n as [|n IHn]; (destruct l; simpl in *; [ intros i **; destruct i; simpl; try reflexivity; omega | ]);
+  induction n as [|n IHn]; (destruct l; simpl in *; [ intros i **; destruct i; simpl; try reflexivity; lia | ]);
     intros i **; repeat break_match; subst; try destruct i;
       repeat first [ progress break_match
                    | progress subst
                    | progress boring
                    | progress autorewrite with simpl_nth_default
-                   | omega ].
+                   | lia ].
 Qed.
 
 Hint Rewrite @update_nth_nth_default_full : push_nth_default.
@@ -1380,7 +1382,7 @@ Lemma update_nth_nth_default : forall {A} (d:A) n f l i, (0 <= i < length l)%nat
   if (eq_nat_dec i n) then f (nth_default d l i) else nth_default d l i.
 Proof. intros; rewrite update_nth_nth_default_full; repeat break_match; boring. Qed.
 
-Hint Rewrite @update_nth_nth_default using (omega || distr_length; omega) : push_nth_default.
+Hint Rewrite @update_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
 
 Lemma set_nth_nth_default_full : forall {A} (d:A) n v l i,
   nth_default d (set_nth n v l) i =
@@ -1397,7 +1399,7 @@ Lemma set_nth_nth_default : forall {A} (d:A) n x l i, (0 <= i < length l)%nat ->
   if (eq_nat_dec i n) then x else nth_default d l i.
 Proof. intros; apply update_nth_nth_default; assumption. Qed.
 
-Hint Rewrite @set_nth_nth_default using (omega || distr_length; omega) : push_nth_default.
+Hint Rewrite @set_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
 
 Lemma nth_default_preserves_properties : forall {A} (P : A -> Prop) l n d,
   (forall x, In x l -> P x) -> P d -> P (nth_default d l n).
@@ -1414,7 +1416,7 @@ Proof.
   intros A P l n d H H0.
   destruct (lt_dec n (length l)).
   + rewrite nth_default_eq; auto using nth_In.
-  + rewrite nth_default_out_of_bounds by omega.
+  + rewrite nth_default_out_of_bounds by lia.
     auto.
 Qed.
 
@@ -1452,7 +1454,7 @@ Proof.
   autorewrite with push_firstn; reflexivity.
 Qed.
 
-Hint Rewrite @sum_firstn_all_succ using omega : simpl_sum_firstn.
+Hint Rewrite @sum_firstn_all_succ using lia : simpl_sum_firstn.
 
 Lemma sum_firstn_all : forall n l, (length l <= n)%nat ->
   sum_firstn l n = sum_firstn l (length l).
@@ -1461,7 +1463,7 @@ Proof.
   autorewrite with push_firstn; reflexivity.
 Qed.
 
-Hint Rewrite @sum_firstn_all using omega : simpl_sum_firstn.
+Hint Rewrite @sum_firstn_all using lia : simpl_sum_firstn.
 
 Lemma sum_firstn_succ_default : forall l i,
   sum_firstn l (S i) = (nth_default 0 l i + sum_firstn l i)%Z.
@@ -1469,7 +1471,7 @@ Proof.
   unfold sum_firstn; induction l as [|a l IHl], i;
     intros; autorewrite with simpl_nth_default simpl_firstn simpl_fold_right in *;
       try reflexivity.
-  rewrite IHl; omega.
+  rewrite IHl; lia.
 Qed.
 
 Hint Rewrite @sum_firstn_succ_default : simpl_sum_firstn.
@@ -1509,20 +1511,20 @@ Hint Rewrite @sum_firstn_nil : simpl_sum_firstn.
 Lemma sum_firstn_succ_default_rev : forall l i,
   sum_firstn l i = (sum_firstn l (S i) - nth_default 0 l i)%Z.
 Proof.
-  intros; rewrite sum_firstn_succ_default; omega.
+  intros; rewrite sum_firstn_succ_default; lia.
 Qed.
 
 Lemma sum_firstn_succ_rev : forall l i x,
   nth_error l i = Some x ->
   sum_firstn l i = (sum_firstn l (S i) - x)%Z.
 Proof.
-  intros; erewrite sum_firstn_succ by eassumption; omega.
+  intros; erewrite sum_firstn_succ by eassumption; lia.
 Qed.
 
 Lemma sum_firstn_nonnegative : forall n l, (forall x, In x l -> 0 <= x)%Z
                                        -> (0 <= sum_firstn l n)%Z.
 Proof.
-  induction n as [|n IHn]; destruct l as [|? l]; autorewrite with simpl_sum_firstn; simpl; try omega.
+  induction n as [|n IHn]; destruct l as [|? l]; autorewrite with simpl_sum_firstn; simpl; try lia.
   { specialize (IHn l).
     destruct n; simpl; autorewrite with simpl_sum_firstn simpl_nth_default in *;
       intuition auto with zarith. }
@@ -1535,16 +1537,16 @@ Lemma sum_firstn_app : forall xs ys n,
 Proof.
   induction xs as [|a xs IHxs]; simpl.
   { intros ys n; autorewrite with simpl_sum_firstn; simpl.
-    f_equal; omega. }
+    f_equal; lia. }
   { intros ys [|n]; autorewrite with simpl_sum_firstn; simpl; [ reflexivity | ].
-    rewrite IHxs; omega. }
+    rewrite IHxs; lia. }
 Qed.
 
 Lemma sum_firstn_app_sum : forall xs ys n,
   sum_firstn (xs ++ ys) (length xs + n) = (sum_firstn xs (length xs) + sum_firstn ys n)%Z.
 Proof.
   intros; rewrite sum_firstn_app; autorewrite with simpl_sum_firstn.
-  do 2 f_equal; omega.
+  do 2 f_equal; lia.
 Qed.
 Hint Rewrite @sum_firstn_app_sum : simpl_sum_firstn.
 
@@ -1557,7 +1559,7 @@ Proof. reflexivity. Qed.
 Hint Rewrite sum_nil : push_sum.
 
 Lemma sum_app x y : sum (x ++ y) = (sum x + sum y)%Z.
-Proof. induction x; rewrite ?app_nil_l, <-?app_comm_cons; autorewrite with push_sum; omega. Qed.
+Proof. induction x; rewrite ?app_nil_l, <-?app_comm_cons; autorewrite with push_sum; lia. Qed.
 Hint Rewrite sum_app : push_sum.
 
 Lemma nth_error_skipn : forall {A} n (l : list A) m,
@@ -1579,10 +1581,10 @@ Hint Rewrite @nth_default_skipn : push_nth_default.
 Lemma sum_firstn_skipn : forall l n m, sum_firstn l (n + m) = (sum_firstn l n + sum_firstn (skipn n l) m)%Z.
 Proof.
 induction m; intros.
-+ rewrite sum_firstn_0. autorewrite with natsimplify. omega.
++ rewrite sum_firstn_0. autorewrite with natsimplify. lia.
 + rewrite <-plus_n_Sm, !sum_firstn_succ_default.
     rewrite nth_default_skipn.
-    omega.
+    lia.
 Qed.
 
 Lemma nth_default_seq_inbounds d s n i (H:(i < n)%nat) :
@@ -1590,7 +1592,7 @@ Lemma nth_default_seq_inbounds d s n i (H:(i < n)%nat) :
 Proof.
   progress cbv [List.nth_default].
   rewrite nth_error_seq.
-  break_innermost_match; solve [ trivial | omega ].
+  break_innermost_match; solve [ trivial | lia ].
 Qed.
 Hint Rewrite @nth_default_seq_inbounds using lia : push_nth_default.
 
@@ -1601,7 +1603,7 @@ intros l n m H.
 rewrite sum_firstn_skipn.
 pose proof (sum_firstn_nonnegative m (skipn n l)) as Hskipn_nonneg.
 match type of Hskipn_nonneg with
-  ?P -> _ => assert P as Q; [ | specialize (Hskipn_nonneg Q); omega ] end.
+  ?P -> _ => assert P as Q; [ | specialize (Hskipn_nonneg Q); lia ] end.
 intros x HIn_skipn.
 apply In_skipn in HIn_skipn.
 auto.
@@ -1612,7 +1614,7 @@ Lemma sum_firstn_prefix_le : forall l n m, (forall x, In x l -> (0 <= x)%Z) ->
                                             (sum_firstn l n <= sum_firstn l m)%Z.
 Proof.
 intros l n m H H0.
-replace m with (n + (m - n))%nat by omega.
+replace m with (n + (m - n))%nat by lia.
 auto using sum_firstn_prefix_le'.
 Qed.
 
@@ -1623,24 +1625,24 @@ Lemma sum_firstn_pos_lt_succ : forall l n m, (forall x, In x l -> (0 <= x)%Z) ->
 Proof.
 intros l n m H H0 H1.
 destruct (le_dec n m); auto.
-replace n with (m + (n - m))%nat in H1 by omega.
+replace n with (m + (n - m))%nat in H1 by lia.
 rewrite sum_firstn_skipn in H1.
 rewrite sum_firstn_succ_default in *.
-match goal with H : (?a + ?b < ?c + ?a)%Z |- _ => assert (H2 : (b < c)%Z) by omega end.
+match goal with H : (?a + ?b < ?c + ?a)%Z |- _ => assert (H2 : (b < c)%Z) by lia end.
 destruct (lt_dec m (length l)). {
     rewrite skipn_nth_default with (d := 0%Z) in H2 by assumption.
-    replace (n - m)%nat with (S (n - S m))%nat in H2 by omega.
+    replace (n - m)%nat with (S (n - S m))%nat in H2 by lia.
     rewrite sum_firstn_succ_cons in H2.
     pose proof (sum_firstn_nonnegative (n - S m) (skipn (S m) l)) as H3.
     match type of H3 with
-      ?P -> _ => assert P as Q; [ | specialize (H3 Q); omega ] end.
+      ?P -> _ => assert P as Q; [ | specialize (H3 Q); lia ] end.
     intros ? A.
     apply In_skipn in A.
     apply H in A.
-    omega.
+    lia.
 } {
-    rewrite skipn_all, nth_default_out_of_bounds in H2 by omega.
-    rewrite sum_firstn_nil in H2; omega.
+    rewrite skipn_all, nth_default_out_of_bounds in H2 by lia.
+    rewrite sum_firstn_nil in H2; lia.
 }
 Qed.
 
@@ -1668,23 +1670,23 @@ Proof.
   induction ls1 as [|a ls1 IHls1], ls2.
   + cbv [map2 length min].
     intros.
-    break_match; try omega.
+    break_match; try lia.
     apply nth_default_nil.
   + cbv [map2 length min].
     intros.
-    break_match; try omega.
+    break_match; try lia.
     apply nth_default_nil.
   + cbv [map2 length min].
     intros.
-    break_match; try omega.
+    break_match; try lia.
     apply nth_default_nil.
   + simpl.
     destruct i.
     - intros. rewrite !nth_default_cons.
-      break_match; auto; omega.
+      break_match; auto; lia.
     - intros d d1 d2. rewrite !nth_default_cons_S.
       rewrite IHls1 with (d1 := d1) (d2 := d2).
-      repeat break_match; auto; omega.
+      repeat break_match; auto; lia.
 Qed.
 
 Lemma map2_cons : forall A B C (f : A -> B -> C) ls1 ls2 a b,
@@ -1731,7 +1733,7 @@ Section OpaqueMap2.
       map2 f (ls1 ++ ls1') (ls2 ++ ls2') = map2 f ls1 ls2 ++ map2 f ls1' ls2'.
   Proof.
     induction ls1 as [|a ls1 IHls1], ls2; intros; rewrite ?map2_nil_r, ?app_nil_l; try congruence;
-      simpl_list_lengths; try omega.
+      simpl_list_lengths; try lia.
     rewrite <-!app_comm_cons, !map2_cons.
     rewrite IHls1; auto.
   Qed.
@@ -1780,16 +1782,16 @@ Proof.
 
   + revert xs ys H H0 H1.
     induction i as [|i IHi]; intros xs ys H H0 H1; destruct H0; distr_length; autorewrite with push_nth_default; auto.
-    eapply IHi; auto. omega.
+    eapply IHi; auto. lia.
   + revert xs ys H H0; induction xs as [|a xs IHxs]; intros ys H H0; destruct ys; distr_length; econstructor.
     - specialize (H0 0%nat).
       autorewrite with push_nth_default in *; auto.
-      apply H0; omega.
-    - apply IHxs; try omega.
+      apply H0; lia.
+    - apply IHxs; try lia.
       intros i H1.
       specialize (H0 (S i)).
       autorewrite with push_nth_default in *; auto.
-      apply H0; omega.
+      apply H0; lia.
 Qed.
 
 Lemma Forall2_forall_iff' : forall {A} R (xs ys : list A) d, length xs = length ys ->
@@ -1801,16 +1803,16 @@ Lemma nth_default_firstn : forall {A} (d : A) l i n,
                                  then if lt_dec i n then nth_default d l i else d
                                  else nth_default d l i.
 Proof.
-  intros A d l i; induction n as [|n IHn]; break_match; autorewrite with push_nth_default; auto; try omega.
-  + rewrite (firstn_succ d) by omega.
+  intros A d l i; induction n as [|n IHn]; break_match; autorewrite with push_nth_default; auto; try lia.
+  + rewrite (firstn_succ d) by lia.
     autorewrite with push_nth_default; repeat (break_match_hyps; break_match; distr_length);
-      rewrite Min.min_l in * by omega; try omega.
-    - apply IHn; omega.
-    - replace i with n in * by omega.
+      rewrite Min.min_l in * by lia; try lia.
+    - apply IHn; lia.
+    - replace i with n in * by lia.
       rewrite Nat.sub_diag.
       autorewrite with push_nth_default; auto.
   + rewrite nth_default_out_of_bounds; break_match_hyps; distr_length; auto; lia.
-  + rewrite firstn_all2 by omega.
+  + rewrite firstn_all2 by lia.
     auto.
 Qed.
 Hint Rewrite @nth_default_firstn : push_nth_default.
@@ -1917,8 +1919,8 @@ Proof.
   cbv [expand_list_helper]; revert idx H.
   induction n as [|n IHn]; cbn; intros.
   { reflexivity. }
-  { rewrite IHn by omega.
-    erewrite (@skipn_nth_default _ idx ls) by omega.
+  { rewrite IHn by lia.
+    erewrite (@skipn_nth_default _ idx ls) by lia.
     reflexivity. }
 Qed.
 
@@ -2082,7 +2084,7 @@ Proof. induction xs; cbn; intro H; rewrite ?H; auto. Qed.
 Lemma nth_default_repeat A (v:A) n (d:A) i : nth_default d (repeat v n) i = if dec (i < n)%nat then v else d.
 Proof.
   revert i; induction n as [|n IHn], i; cbn; try reflexivity.
-  rewrite nth_default_cons_S, IHn; do 2 edestruct dec; try reflexivity; omega.
+  rewrite nth_default_cons_S, IHn; do 2 edestruct dec; try reflexivity; lia.
 Qed.
 Lemma fold_right_if_dec_eq_seq A start len i f (x v : A)
   : ((start <= i < start + len)%nat -> f i v = x)
@@ -2090,14 +2092,14 @@ Lemma fold_right_if_dec_eq_seq A start len i f (x v : A)
     -> fold_right f v (seq start len) = if dec (start <= i < start + len)%nat then x else v.
 Proof.
   revert start v; induction len as [|len IHlen]; intros start v H H'; [ | rewrite seq_snoc, fold_right_app; cbn [fold_right] ].
-  { edestruct dec; try reflexivity; omega. }
-  { destruct (dec (i = (start + len)%nat)); subst; [ | rewrite H' by omega ];
+  { edestruct dec; try reflexivity; lia. }
+  { destruct (dec (i = (start + len)%nat)); subst; [ | rewrite H' by lia ];
       rewrite IHlen; eauto; intros; clear IHlen;
         repeat match goal with
                | _ => reflexivity
-               | _ => omega
+               | _ => lia
                | _ => progress subst
-               | _ => progress specialize_by omega
+               | _ => progress specialize_by lia
                | [ H : context[dec ?P] |- _ ] => destruct (dec P)
                | [ |- context[dec ?P] ] => destruct (dec P)
                | [ H : f _ _ = _ |- _ ] => rewrite H
@@ -2162,21 +2164,20 @@ Lemma nth_error_firstn A ls n i
   : List.nth_error (@List.firstn A n ls) i = if lt_dec i n then List.nth_error ls i else None.
 Proof.
   revert ls i; induction n, ls, i; cbn; try reflexivity; destruct lt_dec; try reflexivity; rewrite IHn.
-  all: destruct lt_dec; try reflexivity; omega.
+  all: destruct lt_dec; try reflexivity; lia.
 Qed.
 
 Lemma nth_error_rev A n ls : List.nth_error (@List.rev A ls) n = if lt_dec n (length ls) then List.nth_error ls (length ls - S n) else None.
 Proof.
-  destruct lt_dec; [ | rewrite nth_error_length_error; rewrite ?List.rev_length; try reflexivity; omega ].
-  revert dependent n; induction ls as [|x xs IHxs]; cbn [length List.rev]; try omega; try reflexivity; intros.
-  { destruct n; reflexivity. }
+  destruct lt_dec; [ | rewrite nth_error_length_error; rewrite ?List.rev_length; try reflexivity; lia ].
+  revert dependent n; induction ls as [|x xs IHxs]; cbn [length List.rev]; try lia; try reflexivity; intros.
   { rewrite nth_error_app, List.rev_length, Nat.sub_succ.
     destruct lt_dec.
-    { rewrite IHxs by omega.
-      rewrite <- (Nat.succ_pred_pos (length xs - n)) by omega.
+    { rewrite IHxs by lia.
+      rewrite <- (Nat.succ_pred_pos (length xs - n)) by lia.
       cbn [List.nth_error].
-      f_equal; omega. }
-    { assert (n = length xs) by omega; subst.
+      f_equal; lia. }
+    { assert (n = length xs) by lia; subst.
       rewrite Nat.sub_diag.
       reflexivity. } }
 Qed.

--- a/src/Rewriter/Util/ListUtil.v
+++ b/src/Rewriter/Util/ListUtil.v
@@ -2170,7 +2170,7 @@ Qed.
 Lemma nth_error_rev A n ls : List.nth_error (@List.rev A ls) n = if lt_dec n (length ls) then List.nth_error ls (length ls - S n) else None.
 Proof.
   destruct lt_dec; [ | rewrite nth_error_length_error; rewrite ?List.rev_length; try reflexivity; lia ].
-  revert dependent n; induction ls as [|x xs IHxs]; cbn [length List.rev]; try lia; try reflexivity; intros.
+  revert dependent n; induction ls as [|x xs IHxs]; cbn [length List.rev]; try reflexivity; intros; try ((idtac + exfalso); lia).
   { rewrite nth_error_app, List.rev_length, Nat.sub_succ.
     destruct lt_dec.
     { rewrite IHxs by lia.

--- a/src/Rewriter/Util/NatUtil.v
+++ b/src/Rewriter/Util/NatUtil.v
@@ -1,5 +1,7 @@
 Require Coq.Logic.Eqdep_dec.
-Require Import Coq.Numbers.Natural.Peano.NPeano Coq.omega.Omega.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Arith.Arith.
+Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Coq.Classes.Morphisms.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Coq.micromega.Lia.
@@ -38,25 +40,25 @@ Proof. apply Nat.mod_bound_pos; lia. Qed.
 
 Hint Resolve mod_bound_nonneg mod_bound_lt : arith.
 
-Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using omega : natsimplify.
+Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using lia : natsimplify.
 
 Hint Rewrite sub_diag add_0_l add_0_r sub_0_r sub_succ : natsimplify.
 
 Local Open Scope nat_scope.
 
 Lemma min_def {x y} : min x y = x - (x - y).
-Proof. apply Min.min_case_strong; omega. Qed.
+Proof. apply Min.min_case_strong; lia. Qed.
 Lemma max_def {x y} : max x y = x + (y - x).
-Proof. apply Max.max_case_strong; omega. Qed.
-Ltac coq_omega := omega.
-Ltac handle_min_max_for_omega_gen min max :=
+Proof. apply Max.max_case_strong; lia. Qed.
+Ltac coq_lia := lia.
+Ltac handle_min_max_for_lia_gen min max :=
   repeat match goal with
          | [ H : context[min _ _] |- _ ] => rewrite !min_def in H || setoid_rewrite min_def in H
          | [ H : context[max _ _] |- _ ] => rewrite !max_def in H || setoid_rewrite max_def in H
          | [ |- context[min _ _] ] => rewrite !min_def || setoid_rewrite min_def
          | [ |- context[max _ _] ] => rewrite !max_def || setoid_rewrite max_def
          end.
-Ltac handle_min_max_for_omega_case_gen min max :=
+Ltac handle_min_max_for_lia_case_gen min max :=
   repeat match goal with
          | [ H : context[min _ _] |- _ ] => revert H
          | [ H : context[max _ _] |- _ ] => revert H
@@ -64,28 +66,28 @@ Ltac handle_min_max_for_omega_case_gen min max :=
          | [ |- context[max _ _] ] => apply Max.max_case_strong
          end;
   intros.
-Ltac handle_min_max_for_omega := handle_min_max_for_omega_gen min max.
-Ltac handle_min_max_for_omega_case := handle_min_max_for_omega_case_gen min max.
+Ltac handle_min_max_for_lia := handle_min_max_for_lia_gen min max.
+Ltac handle_min_max_for_lia_case := handle_min_max_for_lia_case_gen min max.
 (* In 8.4, Nat.min is a definition, so we need to unfold it *)
-Ltac handle_min_max_for_omega_compat_84 :=
+Ltac handle_min_max_for_lia_compat_84 :=
   let min := (eval cbv [min] in min) in
   let max := (eval cbv [max] in max) in
-  handle_min_max_for_omega_gen min max.
-Ltac handle_min_max_for_omega_case_compat_84 :=
+  handle_min_max_for_lia_gen min max.
+Ltac handle_min_max_for_lia_case_compat_84 :=
   let min := (eval cbv [min] in min) in
   let max := (eval cbv [max] in max) in
-  handle_min_max_for_omega_case_gen min max.
-Ltac omega_with_min_max :=
-  handle_min_max_for_omega;
-  try handle_min_max_for_omega_compat_84;
-  omega.
-Ltac omega_with_min_max_case :=
-  handle_min_max_for_omega_case;
-  try handle_min_max_for_omega_case_compat_84;
-  omega.
-Tactic Notation "omega" := coq_omega.
-Tactic Notation "omega" "*" := omega_with_min_max_case.
-Tactic Notation "omega" "**" := omega_with_min_max.
+  handle_min_max_for_lia_case_gen min max.
+Ltac lia_with_min_max :=
+  handle_min_max_for_lia;
+  try handle_min_max_for_lia_compat_84;
+  lia.
+Ltac lia_with_min_max_case :=
+  handle_min_max_for_lia_case;
+  try handle_min_max_for_lia_case_compat_84;
+  lia.
+Tactic Notation "lia" := coq_lia.
+Tactic Notation "lia" "*" := lia_with_min_max_case.
+Tactic Notation "lia" "**" := lia_with_min_max.
 
 Global Instance nat_rect_Proper {P} : Proper (Logic.eq ==> forall_relation (fun _ => forall_relation (fun _ => Logic.eq)) ==> forall_relation (fun _ => Logic.eq)) (@nat_rect P).
 Proof.
@@ -148,7 +150,7 @@ Ltac nat_beq_to_eq :=
 Lemma div_minus : forall a b, b <> 0 -> (a + b) / b = a / b + 1.
 Proof.
   intros a b H.
-  assert (H0 : b = 1 * b) by omega.
+  assert (H0 : b = 1 * b) by lia.
   rewrite H0 at 1.
   rewrite <- Nat.div_add by auto.
   reflexivity.
@@ -157,7 +159,7 @@ Qed.
 Lemma pred_mod : forall m, (0 < m)%nat -> ((pred m) mod m)%nat = pred m.
 Proof.
   intros m H; apply Nat.mod_small.
-  destruct m; try omega; rewrite Nat.pred_succ; auto.
+  destruct m; try lia; rewrite Nat.pred_succ; auto.
 Qed.
 
 Lemma div_add_l' : forall a b c, a <> 0 -> (a * b + c) / a = b + c / a.
@@ -177,12 +179,12 @@ Qed.
 
 Lemma mod_div_eq0 : forall a b, b <> 0 -> a mod b / b = 0.
 Proof.
-  intros; apply Nat.div_small, mod_bound_pos; omega.
+  intros; apply Nat.div_small, mod_bound_pos; lia.
 Qed.
 
 Lemma divide2_1mod4_nat : forall c x, c = x / 4 -> x mod 4 = 1 -> exists y, 2 * y = (x / 2).
 Proof.
-  assert (4 <> 0) as ne40 by omega.
+  assert (4 <> 0) as ne40 by lia.
   induction c; intros x H H0; pose proof (div_mod x 4 ne40) as H1; rewrite <- H in H1. {
     rewrite H0 in H1.
     simpl in H1.
@@ -190,23 +192,23 @@ Proof.
     exists 0; auto.
   } {
     rewrite mult_succ_r in H1.
-    assert (4 <= x) as le4x by (apply Nat.div_str_pos_iff; omega).
+    assert (4 <= x) as le4x by (apply Nat.div_str_pos_iff; lia).
     rewrite <- Nat.add_1_r in H.
-    replace x with ((x - 4) + 4) in H by omega.
+    replace x with ((x - 4) + 4) in H by lia.
     rewrite div_minus in H by auto.
     apply Nat.add_cancel_r in H.
-    replace x with ((x - 4) + (1 * 4)) in H0 by omega.
+    replace x with ((x - 4) + (1 * 4)) in H0 by lia.
     rewrite Nat.mod_add in H0 by auto.
     pose proof (IHc _ H H0) as H2.
     destruct H2 as [x0 H2].
     exists (x0 + 1).
     rewrite <- (Nat.sub_add 4 x) in H1 at 1 by auto.
-    replace (4 * c + 4 + x mod 4) with (4 * c + x mod 4 + 4) in H1 by omega.
+    replace (4 * c + 4 + x mod 4) with (4 * c + x mod 4 + 4) in H1 by lia.
     apply Nat.add_cancel_r in H1.
     replace (2 * (x0 + 1)) with (2 * x0 + 2)
       by (rewrite Nat.mul_add_distr_l; auto).
     rewrite H2.
-    rewrite <- Nat.div_add by omega.
+    rewrite <- Nat.div_add by lia.
     f_equal.
     simpl.
     apply Nat.sub_add; auto.
@@ -236,7 +238,7 @@ Qed.
 (* useful for hints *)
 Lemma eq_le_incl_rev : forall a b, a = b -> b <= a.
 Proof.
-  intros; omega.
+  intros; lia.
 Qed.
 
 Lemma beq_nat_eq_nat_dec {R} (x y : nat) (a b : R)
@@ -256,21 +258,21 @@ Hint Resolve pow_nonzero : arith.
 
 Lemma S_pred_nonzero : forall a, (a > 0 -> S (pred a) = a)%nat.
 Proof.
-  destruct a; simpl; omega.
+  destruct a; simpl; lia.
 Qed.
 
-Hint Rewrite S_pred_nonzero using omega : natsimplify.
+Hint Rewrite S_pred_nonzero using lia : natsimplify.
 
 Lemma mod_same_eq a b : a <> 0 -> a = b -> b mod a = 0.
 Proof. intros; subst; apply mod_same; assumption. Qed.
 
-Hint Rewrite @mod_same_eq using omega : natsimplify.
+Hint Rewrite @mod_same_eq using lia : natsimplify.
 Hint Resolve mod_same_eq : arith.
 
 Lemma mod_mod_eq a b c : a <> 0 -> b = c mod a -> b mod a = b.
 Proof. intros; subst; autorewrite with natsimplify; reflexivity. Qed.
 
-Hint Rewrite @mod_mod_eq using (reflexivity || omega) : natsimplify.
+Hint Rewrite @mod_mod_eq using (reflexivity || lia) : natsimplify.
 
 Local Arguments minus !_ !_.
 
@@ -286,15 +288,15 @@ Proof.
       try congruence; try reflexivity.
 Qed.
 
-Hint Rewrite S_mod_full using omega : natsimplify.
+Hint Rewrite S_mod_full using lia : natsimplify.
 
 Lemma S_mod a b : a <> 0 -> S (b mod a) <> a -> (S b) mod a = S (b mod a).
 Proof.
   intros; rewrite S_mod_full by assumption.
-  edestruct eq_nat_dec; omega.
+  edestruct eq_nat_dec; lia.
 Qed.
 
-Hint Rewrite S_mod using (omega || autorewrite with natsimplify; omega) : natsimplify.
+Hint Rewrite S_mod using (lia || autorewrite with natsimplify; lia) : natsimplify.
 
 Lemma eq_nat_dec_refl x : eq_nat_dec x x = left (Logic.eq_refl x).
 Proof.
@@ -314,7 +316,7 @@ Proof.
     | eexists; reflexivity
     | ].
   { specialize (IHm n).
-    destruct IHm as [? IHm]; [ omega | ].
+    destruct IHm as [? IHm]; [ lia | ].
     eexists; rewrite IHm; reflexivity. }
 Qed.
 
@@ -350,7 +352,7 @@ Proof. edestruct lt_dec_right_val; assumption. Qed.
 Hint Rewrite lt_dec_irrefl : natsimplify.
 
 Lemma not_lt_n_pred_n n : ~n < pred n.
-Proof. destruct n; simpl; omega. Qed.
+Proof. destruct n; simpl; lia. Qed.
 
 Lemma lt_dec_n_pred_n n : lt_dec n (pred n) = right (proj1_sig (@lt_dec_right_val _ _ (not_lt_n_pred_n n))).
 Proof. edestruct lt_dec_right_val; assumption. Qed.
@@ -358,44 +360,44 @@ Hint Rewrite lt_dec_n_pred_n : natsimplify.
 
 Lemma le_dec_refl n : le_dec n n = left (le_refl n).
 Proof.
-  edestruct le_dec; try omega.
+  edestruct le_dec; try lia.
   apply f_equal, le_unique.
 Qed.
 Hint Rewrite le_dec_refl : natsimplify.
 
 Lemma le_dec_pred_l n : le_dec (pred n) n = left (le_pred_l n).
 Proof.
-  edestruct le_dec; [ | destruct n; simpl in *; omega ].
+  edestruct le_dec; [ | destruct n; simpl in *; lia ].
   apply f_equal, le_unique.
 Qed.
 Hint Rewrite le_dec_pred_l : natsimplify.
 
 Lemma le_pred_plus_same n : n <= pred (n + n).
-Proof. destruct n; simpl; omega. Qed.
+Proof. destruct n; simpl; lia. Qed.
 
 Lemma le_dec_pred_plus_same n : le_dec n (pred (n + n)) = left (le_pred_plus_same n).
 Proof.
-  edestruct le_dec; [ | destruct n; simpl in *; omega ].
+  edestruct le_dec; [ | destruct n; simpl in *; lia ].
   apply f_equal, le_unique.
 Qed.
 Hint Rewrite le_dec_pred_plus_same : natsimplify.
 
 Lemma minus_S_diag x : (S x - x = 1)%nat.
-Proof. omega. Qed.
+Proof. lia. Qed.
 Hint Rewrite minus_S_diag : natsimplify.
 
 Lemma min_idempotent_S_l x : min (S x) x = x.
-Proof. omega *. Qed.
+Proof. lia *. Qed.
 Hint Rewrite min_idempotent_S_l : natsimplify.
 
 Lemma min_idempotent_S_r x : min x (S x) = x.
-Proof. omega *. Qed.
+Proof. lia *. Qed.
 Hint Rewrite min_idempotent_S_r : natsimplify.
 
 Lemma mod_pow_same b e : b <> 0 -> e <> 0 -> b^e mod b = 0.
 Proof.
-  intros; destruct e as [|e]; [ omega | simpl ].
-  rewrite mul_comm, mod_mul by omega; omega.
+  intros; destruct e as [|e]; [ lia | simpl ].
+  rewrite mul_comm, mod_mul by lia; lia.
 Qed.
 
 Lemma setbit_high : forall x i, (x < 2^i -> setbit x i = x + 2^i)%nat.
@@ -405,24 +407,24 @@ Proof.
   destruct (beq_nat i n) eqn:H'; simpl.
   { apply beq_nat_true in H'; subst.
     symmetry; apply testbit_true.
-    rewrite div_minus, div_small by omega.
+    rewrite div_minus, div_small by lia.
     reflexivity. }
   { assert (H'' : (((x + 2 ^ i) / 2 ^ n) mod 2) = ((x / 2 ^ n) mod 2)).
     { assert (2^(i-n) <> 0) by auto with arith.
-      assert (2^(i-n) <> 0) by omega.
+      assert (2^(i-n) <> 0) by lia.
       destruct (lt_eq_lt_dec i n) as [ [?|?] | ? ]; [ | subst; rewrite <- beq_nat_refl in H'; congruence | ].
-      { assert (i <= n - 1) by omega.
+      { assert (i <= n - 1) by lia.
         assert (2^i <= 2^n) by auto using pow_le_mono_r with arith.
         assert (2^i <= 2^(n - 1)) by auto using pow_le_mono_r with arith.
         assert (2^(n-1) <> 0) by auto with arith.
         assert (2^(n-1) + 2^(n-1) = 2^n)
-          by (transitivity (2^(S (n - 1))); [ simpl; omega | apply f_equal; omega ]).
-        assert ((2^(n - 1) - 1) + (2^(n - 1)) < 2^n) by omega.
-        rewrite !div_small; try omega. }
+          by (transitivity (2^(S (n - 1))); [ simpl; lia | apply f_equal; lia ]).
+        assert ((2^(n - 1) - 1) + (2^(n - 1)) < 2^n) by lia.
+        rewrite !div_small; try lia. }
       { replace (2^i) with (2^(i - n) * 2^n)
-          by (rewrite <- pow_add_r, ?le_plus_minus_r, ?sub_add by omega; omega).
+          by (rewrite <- pow_add_r, ?le_plus_minus_r, ?sub_add by lia; lia).
         rewrite div_add by auto with arith.
-        rewrite <- add_mod_idemp_r, mod_pow_same, add_0_r by omega.
+        rewrite <- add_mod_idemp_r, mod_pow_same, add_0_r by lia.
         reflexivity. } }
     { match goal with
       | [ |- ?x = ?y ]
@@ -436,7 +438,7 @@ Proof.
 Qed.
 
 Lemma max_0_iff a b : Nat.max a b = 0%nat <-> (a = 0%nat /\ b = 0%nat).
-Proof. omega **. Qed.
+Proof. lia **. Qed.
 
 Lemma push_f_nat_rect {P P'} (f : P -> P') PO PS PS' n
       (HS : forall x rec, f (PS x rec)

--- a/src/Rewriter/Util/NatUtil.v
+++ b/src/Rewriter/Util/NatUtil.v
@@ -360,14 +360,14 @@ Hint Rewrite lt_dec_n_pred_n : natsimplify.
 
 Lemma le_dec_refl n : le_dec n n = left (le_refl n).
 Proof.
-  edestruct le_dec; try lia.
+  edestruct le_dec; try ((idtac + exfalso); lia).
   apply f_equal, le_unique.
 Qed.
 Hint Rewrite le_dec_refl : natsimplify.
 
 Lemma le_dec_pred_l n : le_dec (pred n) n = left (le_pred_l n).
 Proof.
-  edestruct le_dec; [ | destruct n; simpl in *; lia ].
+  edestruct le_dec; [ | destruct n; simpl in *; (idtac + exfalso); lia ].
   apply f_equal, le_unique.
 Qed.
 Hint Rewrite le_dec_pred_l : natsimplify.
@@ -377,7 +377,7 @@ Proof. destruct n; simpl; lia. Qed.
 
 Lemma le_dec_pred_plus_same n : le_dec n (pred (n + n)) = left (le_pred_plus_same n).
 Proof.
-  edestruct le_dec; [ | destruct n; simpl in *; lia ].
+  edestruct le_dec; [ | destruct n; simpl in *; (idtac + exfalso); lia ].
   apply f_equal, le_unique.
 Qed.
 Hint Rewrite le_dec_pred_plus_same : natsimplify.


### PR DESCRIPTION
The `omega` tactic is deprecated in new versions of Coq.

<details><summary>Timing Diff</summary>
<p>

```
   After |  Peak Mem | File Name                                          |   Before |  Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
---------------------------------------------------------------------------------------------------------------------------------------------------------
8m52.15s | 956024 ko | Total Time / Peak Mem                              | 8m43.86s | 956004 ko || +0m08.29s ||        20 ko |   +1.58% |         +0.00%
---------------------------------------------------------------------------------------------------------------------------------------------------------
1m59.46s | 955892 ko | Rewriter/Rewriter/Wf                               | 1m56.08s | 955480 ko || +0m03.38s ||       412 ko |   +2.91% |         +0.04%
1m02.72s | 956024 ko | Rewriter/Rewriter/InterpProofs                     | 1m02.69s | 956004 ko || +0m00.03s ||        20 ko |   +0.04% |         +0.00%
0m48.84s | 868892 ko | Rewriter/Rewriter/ProofsCommon                     | 0m48.67s | 869796 ko || +0m00.17s ||      -904 ko |   +0.34% |         -0.10%
0m46.61s | 767016 ko | Rewriter/Language/UnderLetsProofs                  | 0m46.38s | 767348 ko || +0m00.22s ||      -332 ko |   +0.49% |         -0.04%
0m39.00s | 888416 ko | Rewriter/Rewriter/Examples/SieveOfEratosthenes     | 0m38.05s | 888556 ko || +0m00.95s ||      -140 ko |   +2.49% |         -0.01%
0m35.33s | 812028 ko | Rewriter/Rewriter/Examples                         | 0m34.42s | 811640 ko || +0m00.90s ||       388 ko |   +2.64% |         +0.04%
0m32.40s | 812368 ko | Rewriter/Rewriter/Examples/PrefixSums              | 0m31.70s | 809164 ko || +0m00.69s ||      3204 ko |   +2.20% |         +0.39%
0m22.57s | 633868 ko | Rewriter/Language/Wf                               | 0m22.06s | 633352 ko || +0m00.51s ||       516 ko |   +2.31% |         +0.08%
0m19.32s | 696676 ko | Rewriter/Rewriter/Examples/LiftLetsMap             | 0m18.89s | 696420 ko || +0m00.42s ||       256 ko |   +2.27% |         +0.03%
0m18.73s | 612372 ko | Rewriter/Language/Inversion                        | 0m18.70s | 612488 ko || +0m00.03s ||      -116 ko |   +0.16% |         -0.01%
0m15.32s | 685284 ko | Rewriter/Rewriter/Examples/Plus0Tree               | 0m14.87s | 685252 ko || +0m00.45s ||        32 ko |   +3.02% |         +0.00%
0m15.10s | 685552 ko | Rewriter/Rewriter/Examples/UnderLetsPlus0          | 0m14.68s | 685316 ko || +0m00.41s ||       236 ko |   +2.86% |         +0.03%
0m14.12s | 741332 ko | Rewriter/Demo                                      | 0m14.42s | 745660 ko || -0m00.30s ||     -4328 ko |   -2.08% |         -0.58%
0m12.69s | 640980 ko | Rewriter/Language/IdentifiersLibraryProofs         | 0m13.05s | 640948 ko || -0m00.36s ||        32 ko |   -2.75% |         +0.00%
0m06.57s | 501448 ko | Rewriter/Util/ListUtil                             | 0m06.21s | 499796 ko || +0m00.36s ||      1652 ko |   +5.79% |         +0.33%
0m04.43s | 527840 ko | Rewriter/Language/IdentifiersBasicLibrary          | 0m04.59s | 527572 ko || -0m00.16s ||       268 ko |   -3.48% |         +0.05%
0m01.87s | 577848 ko | Rewriter/Rewriter/Examples/PerfTesting/Harness     | 0m01.89s | 577352 ko || -0m00.01s ||       496 ko |   -1.05% |         +0.08%
0m01.62s | 457404 ko | Rewriter/Util/NatUtil                              | 0m01.34s | 462232 ko || +0m00.28s ||     -4828 ko |  +20.89% |         -1.04%
0m01.56s | 519868 ko | Rewriter/Language/IdentifiersLibrary               | 0m01.56s | 520084 ko || +0m00.00s ||      -216 ko |   +0.00% |         -0.04%
0m01.36s | 515684 ko | Rewriter/Rewriter/Rewriter                         | 0m01.28s | 515968 ko || +0m00.08s ||      -284 ko |   +6.25% |         -0.05%
0m01.22s | 517836 ko | Rewriter/Rewriter/Reify                            | 0m01.29s | 517768 ko || -0m00.07s ||        68 ko |   -5.42% |         +0.01%
0m01.21s | 537252 ko | Rewriter/Rewriter/AllTactics                       | 0m01.10s | 537316 ko || +0m00.10s ||       -64 ko |   +9.99% |         -0.01%
0m01.15s | 477552 ko | Rewriter/Language/Language                         | 0m01.16s | 477224 ko || -0m00.01s ||       328 ko |   -0.86% |         +0.06%
0m00.94s | 520056 ko | Rewriter/Rewriter/ProofsCommonTactics              | 0m00.88s | 519996 ko || +0m00.05s ||        60 ko |   +6.81% |         +0.01%
0m00.90s | 560264 ko | Rewriter/Rewriter/Examples/PerfTesting/All         | 0m00.83s | 560480 ko || +0m00.07s ||      -216 ko |   +8.43% |         -0.03%
0m00.90s | 534680 ko | Rewriter/Rewriter/Examples/PerfTesting/Settings    | 0m00.85s | 534676 ko || +0m00.05s ||         4 ko |   +5.88% |         +0.00%
0m00.88s | 527028 ko | Rewriter/Util/plugins/RewriterBuildRegistryImports | 0m00.84s | 526908 ko || +0m00.04s ||       120 ko |   +4.76% |         +0.02%
0m00.85s | 505752 ko | Rewriter/Language/IdentifiersGenerate              | 0m00.85s | 505508 ko || +0m00.00s ||       244 ko |   +0.00% |         +0.04%
0m00.83s | 506904 ko | Rewriter/Language/IdentifiersGenerateProofs        | 0m00.85s | 506920 ko || -0m00.02s ||       -16 ko |   -2.35% |         -0.00%
0m00.82s | 529788 ko | Rewriter/Util/plugins/RewriterBuild                | 0m00.82s | 532972 ko || +0m00.00s ||     -3184 ko |   +0.00% |         -0.59%
0m00.80s | 528672 ko | Rewriter/Util/plugins/RewriterBuildRegistry        | 0m00.80s | 532352 ko || +0m00.00s ||     -3680 ko |   +0.00% |         -0.69%
0m00.70s | 457900 ko | Rewriter/Util/Bool/Reflect                         | 0m00.70s | 457084 ko || +0m00.00s ||       816 ko |   +0.00% |         +0.17%
0m00.55s | 473748 ko | Rewriter/Language/IdentifiersBasicGenerate         | 0m00.57s | 473808 ko || -0m00.01s ||       -60 ko |   -3.50% |         -0.01%
0m00.48s | 462984 ko | Rewriter/Language/UnderLets                        | 0m00.49s | 462976 ko || -0m00.01s ||         8 ko |   -2.04% |         +0.00%
0m00.30s | 398428 ko | Rewriter/Language/PreLemmas                        | 0m00.30s | 397640 ko || +0m00.00s ||       788 ko |   +0.00% |         +0.19%

```
</p>
 