### PR TITLE
Finally, remove all uses of funext

### DIFF
--- a/src/Rewriter/Language/Inversion.v
+++ b/src/Rewriter/Language/Inversion.v
@@ -11,6 +11,7 @@ Require Import Rewriter.Util.CPSNotations.
 Require Import Rewriter.Util.Tactics.DestructHead.
 Require Import Rewriter.Util.Tactics.BreakMatch.
 Require Import Rewriter.Util.Tactics.RewriteHyp.
+Require Import Rewriter.Util.Tactics.SpecializeAllWays.
 Require Import Rewriter.Util.Notations.
 Require Import Rewriter.Util.FixCoqMistakes.
 
@@ -1050,8 +1051,9 @@ Module Compilers.
                                 | [ H : forall a x y, x = y -> _ |- _ ] => specialize (fun a x => H a x x eq_refl)
                                 | [ H : forall x y, _ = ?f x y, H' : context[?f _ _] |- _ ] => rewrite <- H in H'
                                 | [ H : _ |- _ ] => apply H; clear H
-                                | [ |- ex _ ] => do 2 eexists; repeat apply conj; [ | | reflexivity ]
-                                end ].
+                                | [ |- ex _ ] => (do 2 eexists; repeat apply conj; [ | | intros; subst; reflexivity ])
+                                end
+                              | specialize_all_ways; congruence ].
           Qed.
 
           Lemma reflect_list_interp_related_gen_iff {R t ls ls' v}

--- a/src/Rewriter/Language/Language.v
+++ b/src/Rewriter/Language/Language.v
@@ -629,7 +629,7 @@ Module Compilers.
                 => exists fv xv,
                     @interp_related_gen var R _ f fv
                     /\ @interp_related_gen var R _ x xv
-                    /\ fv xv = v2
+                    /\ fv xv == v2
            | expr.Ident t idc
              => fun v2 => interp_ident _ idc == v2
            | expr.Abs s d f1
@@ -644,7 +644,7 @@ Module Compilers.
                     /\ (forall x1 x2,
                            R _ x1 x2
                            -> @interp_related_gen var R d (f x1) (fv x2))
-                    /\ fv xv = v2
+                    /\ fv xv == v2
            end.
 
       Definition interp_related {t} (e : @expr base_type ident (type.interp interp_base_type) t) : type.interp interp_base_type t -> Prop

--- a/src/Rewriter/Language/Wf.v
+++ b/src/Rewriter/Language/Wf.v
@@ -12,6 +12,7 @@ Require Import Rewriter.Util.Tactics.UniquePose.
 Require Import Rewriter.Util.Tactics.SplitInContext.
 Require Import Rewriter.Util.Tactics.SpecializeBy.
 Require Import Rewriter.Util.Tactics.SpecializeAllWays.
+Require Import Rewriter.Util.Tactics.SetoidSubst.
 Require Import Rewriter.Util.Option.
 Require Import Rewriter.Util.NatUtil.
 Require Import Rewriter.Util.Sigma.
@@ -68,8 +69,8 @@ Module Compilers.
       Qed.
 
       Local Instance related_Transitive {t} {R : forall t, relation (interp_base_type t)}
-             {R_sym : forall t, Symmetric (R t)}
-             {R_trans : forall t, Transitive (R t)}
+            {R_sym : forall t, Symmetric (R t)}
+            {R_trans : forall t, Transitive (R t)}
         : Transitive (@type.related base_type interp_base_type R t) | 100.
       Proof.
         induction t; cbn [type.related]; [ exact _ | ].
@@ -81,6 +82,139 @@ Module Compilers.
 
       Global Instance eqv_Transitive {t} : Transitive (@eqv t) | 10 := _.
       Global Instance eqv_Symmetric {t} : Symmetric (@eqv t) | 10 := _.
+
+      Local Ltac t :=
+        try split; repeat intro; subst;
+        repeat first [ etransitivity; (idtac + symmetry); eassumption
+                     | etransitivity; (idtac + symmetry); try eassumption; [] ].
+
+      Section proper.
+        Context {R : forall t, relation (interp_base_type t)}
+                {R_sym : forall t, Symmetric (R t)}
+                {R_trans : forall t, Transitive (R t)}.
+
+        Global Instance related_Proper_related1_impl {t}
+          : Proper (type.related R ==> eq ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related2_impl {t}
+          : Proper (eq ==> type.related R ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related12_impl {t}
+          : Proper (type.related R ==> type.related R ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f_impl {t}
+          : Proper (Basics.flip (type.related R) ==> eq ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related2f_impl {t}
+          : Proper (eq ==> Basics.flip (type.related R) ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f2f_impl {t}
+          : Proper (Basics.flip (type.related R) ==> Basics.flip (type.related R) ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related12f_impl {t}
+          : Proper (type.related R ==> Basics.flip (type.related R) ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f2_impl {t}
+          : Proper (Basics.flip (type.related R) ==> type.related R ==> Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+
+        Global Instance related_Proper_related1_flip_impl {t}
+          : Proper (type.related R ==> eq ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related2_flip_impl {t}
+          : Proper (eq ==> type.related R ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related12_flip_impl {t}
+          : Proper (type.related R ==> type.related R ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f_flip_impl {t}
+          : Proper (Basics.flip (type.related R) ==> eq ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related2f_flip_impl {t}
+          : Proper (eq ==> Basics.flip (type.related R) ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f2f_flip_impl {t}
+          : Proper (Basics.flip (type.related R) ==> Basics.flip (type.related R) ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related12f_flip_impl {t}
+          : Proper (type.related R ==> Basics.flip (type.related R) ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f2_flip_impl {t}
+          : Proper (Basics.flip (type.related R) ==> type.related R ==> Basics.flip Basics.impl)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+
+        Global Instance related_Proper_related1_iff {t}
+          : Proper (type.related R ==> eq ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related2_iff {t}
+          : Proper (eq ==> type.related R ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related12_iff {t}
+          : Proper (type.related R ==> type.related R ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f_iff {t}
+          : Proper (Basics.flip (type.related R) ==> eq ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related2f_iff {t}
+          : Proper (eq ==> Basics.flip (type.related R) ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f2f_iff {t}
+          : Proper (Basics.flip (type.related R) ==> Basics.flip (type.related R) ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related12f_iff {t}
+          : Proper (type.related R ==> Basics.flip (type.related R) ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+
+        Global Instance related_Proper_related1f2_iff {t}
+          : Proper (Basics.flip (type.related R) ==> type.related R ==> iff)
+                   (@type.related base_type interp_base_type R t) | 10.
+        Proof using R_sym R_trans. t. Qed.
+      End proper.
     End eqv.
     Hint Extern 100 (Symmetric (@type.related ?base_type ?interp_base_type ?R ?t))
     => (tryif has_evar R then fail else simple apply (@related_Symmetric base_type interp_base_type t R)) : typeclass_instances.
@@ -345,20 +479,6 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
                 {interp_ident : forall t, ident t -> type.interp interp_base_type t}
                 {interp_ident_Proper : forall t, Proper (eq ==> type.eqv) (interp_ident t)}.
 
-        Lemma eqv_of_interp_related {t e v}
-          : expr.interp_related interp_ident e v
-            -> @type.eqv t (expr.interp interp_ident e) v.
-        Proof using Type.
-          cbv [expr.interp_related]; induction e; cbn [expr.interp_related_gen expr.interp type.related]; cbv [respectful LetIn.Let_In].
-          all: repeat first [ progress intros
-                            | assumption
-                            | solve [ eauto ]
-                            | progress destruct_head'_ex
-                            | progress destruct_head'_and
-                            | progress subst
-                            | match goal with H : _ |- _ => apply H; clear H end ].
-        Qed.
-
         Lemma eqv_of_interp_related_gen {var R t e v1 v2}
               (HR_iff : forall t v1 v2, (exists v, R t v v1 /\ R t v v2) <-> v1 == v2)
           : expr.interp_related_gen interp_ident (var:=var) R e v1
@@ -383,21 +503,10 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
                          | progress subst
                          | solve [ eauto ]
                          | intros; etransitivity; (idtac + symmetry); eassumption
-                         | intro ].
-        Qed.
-
-        Lemma eqv_of_interp_related2 {t e1 e2 v1 v2}
-              (H : e1 = e2 \/ expr.interp interp_ident e1 == expr.interp interp_ident e2)
-          : expr.interp_related interp_ident e1 v1
-            -> expr.interp_related interp_ident e2 v2
-            -> @type.eqv t v1 v2.
-        Proof using Type.
-          intros H1 H2.
-          apply eqv_of_interp_related in H1.
-          apply eqv_of_interp_related in H2.
-          destruct H; subst;
-            repeat first [ etransitivity; (idtac + symmetry); eassumption
-                         | etransitivity; (idtac + symmetry); try eassumption; [] ].
+                         | intro
+                         | match goal with
+                           | [ H : _ == ?x |- _ ] => is_var x; setoid_subst x
+                           end ].
         Qed.
 
         Lemma eqv_iff_interp_related_gen {var R}
@@ -413,7 +522,133 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
               exists (expr.Var v); cbn; assumption. }
         Qed.
 
+        Lemma eqv_iff_interp_related_gen1 {var R}
+              (HR_iff : forall t v1 v2, (exists v, R t v v1 /\ R t v v2) <-> v1 == v2)
+          : forall t v,
+            (exists e, expr.interp_related_gen interp_ident (var:=var) R e v)
+            <-> @type.eqv t v v.
+        Proof using Type.
+          intros; erewrite <- eqv_iff_interp_related_gen by eassumption.
+          split; intros; destruct_head'_ex; destruct_head'_and; eauto.
+        Qed.
+
+        Lemma interp_related_gen_Proper_eqv_impl {var R t}
+              {R_Proper : forall t, Proper (eq ==> type.eqv ==> Basics.impl) (R t)}
+              (HR_iff : forall t v1 v2, (exists v, R t v v1 /\ R t v v2) <-> v1 == v2)
+          : Proper (eq ==> type.eqv ==> Basics.impl) (expr.interp_related_gen (var:=var) (t:=t) interp_ident R).
+        Proof using Type.
+          intros e e' ? x y H H'; subst e'.
+          induction e; cbn [expr.interp_related_gen] in *.
+          all: repeat first [ etransitivity; (idtac + symmetry); eassumption
+                            | eapply R_Proper; try eassumption; reflexivity
+                            | eexists; split; eassumption
+                            | progress destruct_head'_ex
+                            | progress destruct_head'_and
+                            | intro
+                            | (do 2 eexists; repeat apply conj; [ eassumption | eassumption | ])
+                            | match goal with H : _ |- _ => cbn in H; eapply H; clear H end ].
+        Qed.
+
+        Local Hint Extern 5 => symmetry : sym.
+        Lemma interp_related_gen_Proper_eqv_flip_impl {var R t}
+              {R_Proper : forall t, Proper (eq ==> type.eqv ==> Basics.flip Basics.impl) (R t)}
+              (HR_iff : forall t v1 v2, (exists v, R t v v1 /\ R t v v2) <-> v1 == v2)
+          : Proper (eq ==> type.eqv ==> Basics.flip Basics.impl) (expr.interp_related_gen (var:=var) (t:=t) interp_ident R).
+        Proof using Type.
+          repeat intro; subst; eapply @interp_related_gen_Proper_eqv_impl;
+            cbv [Proper respectful Basics.flip Basics.impl] in *;
+            intros; subst; eauto with core sym.
+        Qed.
+
+        Lemma interp_related_gen_Proper_eqv_iff {var R t}
+              {R_Proper : forall t, Proper (eq ==> type.eqv ==> iff) (R t)}
+              (HR_iff : forall t v1 v2, (exists v, R t v v1 /\ R t v v2) <-> v1 == v2)
+          : Proper (eq ==> type.eqv ==> iff) (expr.interp_related_gen (var:=var) (t:=t) interp_ident R).
+        Proof using Type.
+          repeat intro; subst; split; eapply @interp_related_gen_Proper_eqv_impl;
+            cbv [Proper respectful Basics.flip Basics.impl] in *;
+            split_iff; try split;
+              intros; subst; eauto with core sym.
+        Qed.
+
+        Lemma eqv_iff_ex_eqv2 {t} {v1 v2 : type.interp interp_base_type t}
+          : (exists v, v == v1 /\ v == v2) <-> v1 == v2.
+        Proof using Type.
+          clear.
+          split; [ intros [v [? ?] ] | exists v1; split ];
+            try assumption;
+            try (etransitivity; (idtac + symmetry); eassumption).
+        Qed.
+
+        Local Hint Resolve eqv_iff_ex_eqv2 : core.
+
+        Lemma eqv_of_interp_related2 {t e v1 v2}
+          : expr.interp_related interp_ident e v1
+            -> expr.interp_related interp_ident e v2
+            -> @type.eqv t v1 v2.
+        Proof using Type. now apply eqv_of_interp_related_gen. Qed.
+
+
+        Lemma eqv_iff_interp_related
+          : forall t v1 v2,
+            (exists e, expr.interp_related interp_ident e v1
+                       /\ expr.interp_related interp_ident e v2)
+            <-> @type.eqv t v1 v2.
+        Proof using Type. now apply eqv_iff_interp_related_gen. Qed.
+
+        Lemma eqv_iff_interp_related1
+          : forall t v,
+            (exists e, expr.interp_related interp_ident e v)
+            <-> @type.eqv t v v.
+        Proof using Type. now apply eqv_iff_interp_related_gen1. Qed.
+
+        Global Instance interp_related_Proper_eqv_impl {t}
+          : Proper (eq ==> type.eqv ==> Basics.impl) (expr.interp_related (t:=t) interp_ident) | 20.
+        Proof using Type. now apply interp_related_gen_Proper_eqv_impl. Qed.
+
+        Global Instance interp_related_Proper_eqv_flip_impl {t}
+          : Proper (eq ==> type.eqv ==> Basics.flip Basics.impl) (expr.interp_related (t:=t) interp_ident) | 30.
+        Proof using Type. now apply interp_related_gen_Proper_eqv_flip_impl. Qed.
+
+        Global Instance interp_related_Proper_eqv_iff {t}
+          : Proper (eq ==> type.eqv ==> iff) (expr.interp_related (t:=t) interp_ident) | 10.
+        Proof using Type. now apply interp_related_gen_Proper_eqv_iff. Qed.
+
+
+        Lemma eqv_of_interp_related {t e v}
+          : expr.interp_related interp_ident e v
+            -> @type.eqv t (expr.interp interp_ident e) v.
+        Proof using Type.
+          cbv [expr.interp_related]; induction e; cbn [expr.interp_related_gen expr.interp type.related]; cbv [respectful LetIn.Let_In].
+          all: repeat first [ progress intros
+                            | assumption
+                            | solve [ eauto ]
+                            | progress destruct_head'_ex
+                            | progress destruct_head'_and
+                            | progress subst
+                            | match goal with
+                              | [ H : _ == ?x |- _ ] => is_var x; setoid_subst x
+                              end
+                            | match goal with H : _ |- _ => eapply H; clear H end
+                            | match goal with H : _ |- _ => cbn in H; etransitivity; [ eapply H | ]; clear H end ].
+        Qed.
+
+        Lemma eqv_of_interp_related2_or {t e1 e2 v1 v2}
+              (H : e1 = e2 \/ expr.interp interp_ident e1 == expr.interp interp_ident e2)
+          : expr.interp_related interp_ident e1 v1
+            -> expr.interp_related interp_ident e2 v2
+            -> @type.eqv t v1 v2.
+        Proof using Type.
+          intros H1 H2.
+          apply eqv_of_interp_related in H1.
+          apply eqv_of_interp_related in H2.
+          destruct H; subst;
+            repeat first [ etransitivity; (idtac + symmetry); eassumption
+                         | etransitivity; (idtac + symmetry); try eassumption; [] ].
+        Qed.
+
         Lemma interp_related_gen_of_wf {var R G t e1 e2}
+              (HR_iff : forall t v1 v2, (exists v, R t v v1 /\ R t v v2) <-> v1 == v2)
               (HG : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> (R t v1 v2 : Prop))
               (Hwf : wf G e1 e2)
           : @expr.interp_related_gen _ _ _ interp_ident var R t e1 (expr.interp interp_ident e2).
@@ -431,12 +666,35 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
                             | progress subst
                             | apply interp_ident_Proper
                             | match goal with
+                              | [ H : expr.interp_related_gen _ _ _ (expr.interp _ ?f) |- _ ]
+                                => lazymatch goal with
+                                   | [ |- expr.interp _ ?f _ == expr.interp _ ?f _ ] => idtac
+                                   | [ |- expr.interp _ ?f == expr.interp _ ?f ] => idtac
+                                   end;
+                                   eapply eqv_of_interp_related_gen in H; [ | eassumption | eassumption ];
+                                   try (cbn in H; apply H)
+                              | [ H : forall v1 v2, _ -> expr.interp_related_gen _ _ _ (expr.interp _ (?f v2)),
+                                    Hv : _ == ?v
+                                    |- expr.interp _ (?f ?v) == expr.interp _ (?f ?v) ]
+                                => let v1 := fresh "v" in
+                                   destruct (proj2 (HR_iff _ _ _) Hv) as [v1 [? ?] ];
+                                   let T := open_constr:(_) in
+                                   let H' := fresh in
+                                   unshelve (evar (H' : T);
+                                             specialize (H v1 v H'); subst H')
                               | [ |- exists fv xv, _ /\ _ /\ _ ]
                                 => eexists (expr.interp interp_ident (expr.Abs _)), _;
-                                   cbn [expr.interp]; repeat apply conj; [ eassumption | | reflexivity ]
-                              | [ H : _ |- _ ] => apply H; clear H
-                              end ].
+                                   cbn [expr.interp]; repeat apply conj; [ eassumption | | ]
+                              | [ H : _ |- _ ] => tryif constr_eq H HR_iff then fail else (apply H; clear H)
+                              end
+                            | (do 2 eexists; repeat apply conj; [ eassumption | eassumption | ]) ].
         Qed.
+
+        Lemma interp_related_of_wf {G t e1 e2}
+              (HG : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> v1 == v2)
+              (Hwf : wf G e1 e2)
+          : expr.interp_related interp_ident (t:=t) e1 (expr.interp interp_ident e2).
+        Proof using interp_ident_Proper. now eapply interp_related_gen_of_wf; try eassumption. Qed.
       End with_interp.
 
       Section with_var3.


### PR DESCRIPTION
There were two insights that went into making it possible to remove
functional extensionaliy.

1. The insight that went into 4d7999ebb66c1497222d024a1d9f9d0f1ecb2356:
   interp-relatedness implies equivalence.

2. Requiring `f x = v` in the `App`/`LetIn` case of `interp_related_gen`
   et al is essentially saying that, in order to prove
   `interp_related_gen`, we need to materialize an interpretation of the
   function part of applications.  Since interpretation is in general
   highly non-trivial (for `rawexpr`s, `value`s, etc), we must weaken
   this condition.  By instead only requiring `f x == v`, we only
   require being able to manifest *some* function which interprets to
   `v`, a much easier task.  This weakening allows us to prove for each
   interpretation-relation `R` that `(exists e, R e v1 /\ R e v2) <-> v1
   == v2`, i.e., that two interpreted values are equivalent iff there is
   some uninterpreted value which is related to both of them.

   Unfortunately this is not a full specification of
   interpretation-relatedness (we still need to say what it means for a
   particular uninterpreted value to be related to a particular
   interpreted value), and so we still end up doing a lot of work to
   prove various properties.

<details><summary>Timing Diff</summary>
<p>

```
   After |  Peak Mem | File Name                                          |   Before |  Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
---------------------------------------------------------------------------------------------------------------------------------------------------------
9m31.25s | 972156 ko | Total Time / Peak Mem                              | 8m49.94s | 955744 ko || +0m41.31s ||     16412 ko |   +7.79% |         +1.71%
---------------------------------------------------------------------------------------------------------------------------------------------------------
1m14.56s | 859792 ko | Rewriter/Language/UnderLetsProofs                  | 0m46.66s | 767576 ko || +0m27.90s ||     92216 ko |  +59.79% |        +12.01%
0m56.26s | 874108 ko | Rewriter/Rewriter/ProofsCommon                     | 0m48.79s | 869360 ko || +0m07.46s ||      4748 ko |  +15.31% |         +0.54%
0m24.67s | 644504 ko | Rewriter/Language/Wf                               | 0m22.59s | 633232 ko || +0m02.08s ||     11272 ko |   +9.20% |         +1.78%
1m04.38s | 953436 ko | Rewriter/Rewriter/InterpProofs                     | 1m03.09s | 955508 ko || +0m01.28s ||     -2072 ko |   +2.04% |         -0.21%
1m57.29s | 955812 ko | Rewriter/Rewriter/Wf                               | 1m57.19s | 955744 ko || +0m00.09s ||        68 ko |   +0.08% |         +0.00%
0m38.73s | 972156 ko | Rewriter/Rewriter/Examples/SieveOfEratosthenes     | 0m38.15s | 888496 ko || +0m00.57s ||     83660 ko |   +1.52% |         +9.41%
0m34.85s | 811392 ko | Rewriter/Rewriter/Examples                         | 0m34.56s | 811664 ko || +0m00.28s ||      -272 ko |   +0.83% |         -0.03%
0m32.36s | 806524 ko | Rewriter/Rewriter/Examples/PrefixSums              | 0m31.81s | 806696 ko || +0m00.55s ||      -172 ko |   +1.72% |         -0.02%
0m19.35s | 699656 ko | Rewriter/Rewriter/Examples/LiftLetsMap             | 0m19.03s | 696620 ko || +0m00.32s ||      3036 ko |   +1.68% |         +0.43%
0m18.74s | 612996 ko | Rewriter/Language/Inversion                        | 0m18.73s | 612420 ko || +0m00.00s ||       576 ko |   +0.05% |         +0.09%
0m15.07s | 686200 ko | Rewriter/Rewriter/Examples/Plus0Tree               | 0m14.93s | 685612 ko || +0m00.14s ||       588 ko |   +0.93% |         +0.08%
0m14.94s | 685332 ko | Rewriter/Rewriter/Examples/UnderLetsPlus0          | 0m14.75s | 685192 ko || +0m00.18s ||       140 ko |   +1.28% |         +0.02%
0m14.41s | 731276 ko | Rewriter/Demo                                      | 0m14.43s | 743012 ko || -0m00.01s ||    -11736 ko |   -0.13% |         -1.57%
0m13.15s | 637292 ko | Rewriter/Language/IdentifiersLibraryProofs         | 0m13.17s | 640980 ko || -0m00.01s ||     -3688 ko |   -0.15% |         -0.57%
0m06.79s | 503412 ko | Rewriter/Util/ListUtil                             | 0m06.56s | 501208 ko || +0m00.23s ||      2204 ko |   +3.50% |         +0.43%
0m04.58s | 527384 ko | Rewriter/Language/IdentifiersBasicLibrary          | 0m04.57s | 527564 ko || +0m00.00s ||      -180 ko |   +0.21% |         -0.03%
0m01.77s | 577488 ko | Rewriter/Rewriter/Examples/PerfTesting/Harness     | 0m01.87s | 577872 ko || -0m00.10s ||      -384 ko |   -5.34% |         -0.06%
0m01.72s | 457916 ko | Rewriter/Util/NatUtil                              | 0m01.70s | 457296 ko || +0m00.02s ||       620 ko |   +1.17% |         +0.13%
0m01.55s | 521092 ko | Rewriter/Language/IdentifiersLibrary               | 0m01.58s | 519796 ko || -0m00.03s ||      1296 ko |   -1.89% |         +0.24%
0m01.34s | 518212 ko | Rewriter/Rewriter/Rewriter                         | 0m01.37s | 515708 ko || -0m00.03s ||      2504 ko |   -2.18% |         +0.48%
0m01.22s | 518556 ko | Rewriter/Rewriter/Reify                            | 0m01.22s | 517588 ko || +0m00.00s ||       968 ko |   +0.00% |         +0.18%
0m01.18s | 477976 ko | Rewriter/Language/Language                         | 0m01.15s | 477124 ko || +0m00.03s ||       852 ko |   +2.60% |         +0.17%
0m01.14s | 539084 ko | Rewriter/Rewriter/AllTactics                       | 0m01.11s | 537084 ko || +0m00.02s ||      2000 ko |   +2.70% |         +0.37%
0m01.13s | 444328 ko | Rewriter/Util/ListUtil/Forall                      | 0m01.04s | 445248 ko || +0m00.08s ||      -920 ko |   +8.65% |         -0.20%
0m00.95s | 523516 ko | Rewriter/Rewriter/ProofsCommonTactics              | 0m00.95s | 520348 ko || +0m00.00s ||      3168 ko |   +0.00% |         +0.60%
0m00.90s | 506864 ko | Rewriter/Language/IdentifiersGenerate              | 0m00.81s | 505404 ko || +0m00.08s ||      1460 ko |  +11.11% |         +0.28%
0m00.90s | 558172 ko | Rewriter/Rewriter/Examples/PerfTesting/All         | 0m00.87s | 560168 ko || +0m00.03s ||     -1996 ko |   +3.44% |         -0.35%
0m00.89s | 532984 ko | Rewriter/Rewriter/Examples/PerfTesting/Settings    | 0m00.87s | 534512 ko || +0m00.02s ||     -1528 ko |   +2.29% |         -0.28%
0m00.83s | 507180 ko | Rewriter/Language/IdentifiersGenerateProofs        | 0m00.84s | 506900 ko || -0m00.01s ||       280 ko |   -1.19% |         +0.05%
0m00.82s | 530880 ko | Rewriter/Util/plugins/RewriterBuild                | 0m00.79s | 529620 ko || +0m00.02s ||      1260 ko |   +3.79% |         +0.23%
0m00.81s | 530028 ko | Rewriter/Util/plugins/RewriterBuildRegistry        | 0m00.78s | 528980 ko || +0m00.03s ||      1048 ko |   +3.84% |         +0.19%
0m00.78s | 533476 ko | Rewriter/Util/plugins/RewriterBuildRegistryImports | 0m00.80s | 531528 ko || -0m00.02s ||      1948 ko |   -2.50% |         +0.36%
0m00.70s | 458240 ko | Rewriter/Util/Bool/Reflect                         | 0m00.71s | 457920 ko || -0m00.01s ||       320 ko |   -1.40% |         +0.06%
0m00.56s | 473820 ko | Rewriter/Language/IdentifiersBasicGenerate         | 0m00.59s | 473848 ko || -0m00.02s ||       -28 ko |   -5.08% |         -0.00%
0m00.48s | 449072 ko | Rewriter/Util/MSetPositive/Facts                   | 0m00.47s | 449132 ko || +0m00.01s ||       -60 ko |   +2.12% |         -0.01%
0m00.46s | 463164 ko | Rewriter/Language/UnderLets                        | 0m00.46s | 462804 ko || +0m00.00s ||       360 ko |   +0.00% |         +0.07%
0m00.31s | 400688 ko | Rewriter/Language/PreLemmas                        | 0m00.32s | 398084 ko || -0m00.01s ||      2604 ko |   -3.12% |         +0.65%
0m00.27s | 312208 ko | Rewriter/Util/Option                               | 0m00.26s | 311880 ko || +0m00.01s ||       328 ko |   +3.84% |         +0.10%
0m00.18s | 339048 ko | Rewriter/Util/OptionList                           | 0m00.17s | 338844 ko || +0m00.00s ||       204 ko |   +5.88% |         +0.06%
0m00.09s | 202332 ko | Rewriter/Util/ListUtil/SetoidList                  | 0m00.12s | 202224 ko || -0m00.03s ||       108 ko |  -25.00% |         +0.05%
0m00.08s | 133832 ko | Rewriter/Util/Bool                                 | 0m00.08s | 116804 ko || +0m00.00s ||     17028 ko |   +0.00% |        +14.57%
0m00.04s |  57244 ko | Rewriter/Util/Tactics/Contains                     |   N/A    |    N/A    || +0m00.04s ||     57244 ko |        ∞ |              ∞
0m00.03s |  58744 ko | Rewriter/Util/Tactics/SetoidSubst                  |   N/A    |    N/A    || +0m00.03s ||     58744 ko |        ∞ |              ∞

```
</p>