### PR TITLE
Adapting to Coq PR#12960: implicit arguments not any more lost when nesting applicative notations

### DIFF
--- a/src/Rewriter/Rewriter/ProofsCommon.v
+++ b/src/Rewriter/Rewriter/ProofsCommon.v
@@ -3923,7 +3923,7 @@ Module Compilers.
         Definition Wf_GoalT {exprInfo : ExprInfoT} {exprExtraInfo : ExprExtraInfoT} {pkg : package} (Rewriter : RewriterT) : Prop
           := forall var1 var2,
             @Compile.rewrite_rules_goodT
-              base _ ident pattern_ident arg_types var1 var2
+              base _ ident pattern_ident (@arg_types) var1 var2
               (Make.GoalType.rewrite_rules (Rewriter_data Rewriter) _)
               (Make.GoalType.rewrite_rules (Rewriter_data Rewriter) _).
       End GoalType.
@@ -3944,7 +3944,7 @@ Module Compilers.
           := plet data := Rewriter_data Rewriter in
                    specT data
                    -> @Compile.rewrite_rules_interp_goodT
-                        base _ ident pattern_ident arg_types to_typed base_interp ident_interp
+                        base _ ident pattern_ident (@arg_types) (@to_typed) base_interp ident_interp
                         (Make.GoalType.rewrite_rules data _).
       End GoalType.
     End InterpTactics.

--- a/src/Rewriter/Rewriter/Reify.v
+++ b/src/Rewriter/Rewriter/Reify.v
@@ -765,7 +765,7 @@ Module Compilers.
 
           Context (cast_Literal_base_pattern_interp
                    : forall (evm : EvarMap) (t : base),
-                      unification_resultT' (var:=var) arg_types (make_base_Literal_pattern_folded t) evm
+                      unification_resultT' (var:=var) (@arg_types) (make_base_Literal_pattern_folded t) evm
                       -> base.interp base_interp (pattern.base.subst_default (ptype_base' t) evm)).
 
           Fixpoint make_Literal_pattern_interp_helper {t evm T}
@@ -887,7 +887,7 @@ Module Compilers.
                end.
 
           Definition make_interp_rewrite' {t} (idc : ident t)
-                     (pidc := pattern.Ident (of_typed_ident _ idc))
+                     (pidc := pattern.Ident (@of_typed_ident _ idc))
                      (val : with_unification_resultT pidc (type.interp (base.interp base_interp)))
             : option rewrite_ruleT
             := match make_interp_rewrite_pattern pidc as p

--- a/src/Rewriter/Rewriter/Rewriter.v
+++ b/src/Rewriter/Rewriter/Rewriter.v
@@ -1547,7 +1547,7 @@ Module Compilers.
               dummy_count : nat;
               dtree : @Compile.decision_tree raw_ident;
 
-              rewrite_rules : forall var, @Compile.rewrite_rulesT base ident var pattern_ident arg_types ;
+              rewrite_rules : forall var, @Compile.rewrite_rulesT base ident var pattern_ident (@arg_types) ;
               all_rewrite_rules (* adjusted version *) : _;
               all_rewrite_rules_eq : all_rewrite_rules = rewrite_rules;
 
@@ -1555,10 +1555,10 @@ Module Compilers.
 
               rewrite_head0
               := (fun var
-                  => @Compile.assemble_identifier_rewriters base _ base_beq ident var eta_ident_cps pattern_ident arg_types (@unify _ _ pkg) (@unify_unknown _ _ pkg) raw_ident full_types (@invert_bind_args _ _ pkg) (@invert_bind_args_unknown _ _ pkg) type_of raw_to_typed is_simple (Some dtree) (all_rewrite_rules var));
+                  => @Compile.assemble_identifier_rewriters base _ base_beq ident var eta_ident_cps pattern_ident (@arg_types) (@unify _ _ pkg) (@unify_unknown _ _ pkg) raw_ident full_types (@invert_bind_args _ _ pkg) (@invert_bind_args_unknown _ _ pkg) type_of raw_to_typed is_simple (Some dtree) (all_rewrite_rules var));
               rewrite_head_no_dtree0
               := (fun var
-                  => @Compile.assemble_identifier_rewriters base _ base_beq ident var eta_ident_cps pattern_ident arg_types (@unify _ _ pkg) (@unify_unknown _ _ pkg) raw_ident full_types (@invert_bind_args _ _ pkg) (@invert_bind_args_unknown _ _ pkg) type_of raw_to_typed is_simple None (all_rewrite_rules var));
+                  => @Compile.assemble_identifier_rewriters base _ base_beq ident var eta_ident_cps pattern_ident (@arg_types) (@unify _ _ pkg) (@unify_unknown _ _ pkg) raw_ident full_types (@invert_bind_args _ _ pkg) (@invert_bind_args_unknown _ _ pkg) type_of raw_to_typed is_simple None (all_rewrite_rules var));
               rewrite_head (* adjusted version *)
               : forall var (do_again : forall t, @expr.expr (base.type base) ident (@Compile.value _ ident var) (type.base t) -> @UnderLets.UnderLets _ ident var (@expr.expr (base.type base) ident var (type.base t)))
                        t (idc : ident t), @Compile.value_with_lets (base.type base) ident var t;


### PR DESCRIPTION
The code was relying on the implicit arguments being lost, so we add an explicit `@` to preserve the previous behavior, as discussed [here](https://github.com/coq/coq/pull/12960#issuecomment-685091581).

I did not double-check, but, at first view, this is backwards compatible (i.e. the corresponding `@`s behave as a no-op before coq/coq#12960).