### PR TITLE
Fix for PR 13952

### DIFF
--- a/src/Rewriter/Language/Language.v
+++ b/src/Rewriter/Language/Language.v
@@ -300,7 +300,7 @@ Module Compilers.
 
     Class try_make_transport_cpsT {base : Type}
       := try_make_transport_cpsv : forall (P : base -> Type) t1 t2, ~> option (P t1 -> P t2).
-    Hint Mode try_make_transport_cpsT ! : typeclass_instances.
+    (*Hint Mode try_make_transport_cpsT ! : typeclass_instances.*)
     Global Arguments try_make_transport_cpsT : clear implicits.
 
     Class try_make_transport_cps_correctT {base : Type}


### PR DESCRIPTION
coq/coq#13952 means that typeclass resolution can fail to resolve a goal for `try_make_transport_cpsT` while leaving its evar untouched. Somehow the failure of typeclass resolution is not caught correctly by the command:

``` 
Set Typeclasses Debug Verbosity 2.
Time Make myrew := Rewriter For (eval_repeat, eval_rect list, eval_rect nat, eval_Z_to_nat) (with extra idents (Z.add)).
```

However I can't find how / when typeclass resolution is called here, as the ml code does not seem to call resolution directly. To properly use the mode, the ML code should check that the evar for `try_make_transport_cpsT` is properly instantiated, because it might now just be left as stuck. If called from Coq, simply use `solve [typeclasses eauto]` to ensure all goals (even stuck ones) are solved. Simply removing the mode declaration also fixes the problem.