### PR TITLE
Adapt to Coq PR #14379: change of semantics of Reserved Infix "'o'"

### DIFF
--- a/src/Rewriter/Util/Notations.v
+++ b/src/Rewriter/Util/Notations.v
@@ -13,7 +13,6 @@ Reserved Notation "()" (at level 0).
 Reserved Infix "∘" (at level 40, left associativity).
 Reserved Infix "∘ᶠ" (at level 40, left associativity).
 Reserved Infix "∘f" (at level 40, left associativity).
-Reserved Infix "'o'" (at level 40, left associativity).
 Reserved Infix "==" (at level 70, no associativity).
 Reserved Infix "===" (at level 70, no associativity).
 Reserved Infix "====" (at level 70, no associativity).


### PR DESCRIPTION
`Reserved Infix "'o'"` used to reserve `'o'`; with coq/coq#14379, it reserves `o`, leading to a failure to parse some variables named `o`.

The notation `'o'` is actually not used in rewriter and we remove it. If obtaining the former effect is really needed, it should be written `Reserved Infix "''o''"`.

This was detected on Coq's CI. If agreed, it should be compatible and can be merged as soon as now.