### PR TITLE
Drop support for Coq < 8.11, make hint globality explicit

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -18,14 +18,10 @@ jobs:
         - { COQ_VERSION: "8.13.2", COQ_PACKAGE: "coq-8.13.2 libcoq-8.13.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "8.12.2", COQ_PACKAGE: "coq-8.12.2 libcoq-8.12.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "8.11.2", COQ_PACKAGE: "coq-8.11.2 libcoq-8.11.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.10.2", COQ_PACKAGE: "coq-8.10.2 libcoq-8.10.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.9.1" , COQ_PACKAGE: "coq-8.9.1 libcoq-8.9.1-ocaml-dev"  , SKIP_VALIDATE: "1", PPA: "ppa:jgross-h/many-coq-versions" }
         - { COQ_VERSION: "v8.14" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.14-daily" }
         - { COQ_VERSION: "v8.13" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.13-daily" }
         - { COQ_VERSION: "v8.12" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.12-daily" }
         - { COQ_VERSION: "v8.11" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.11-daily" }
-        - { COQ_VERSION: "v8.10" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.10-daily" }
-        - { COQ_VERSION: "v8.9"  , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "1", PPA: "ppa:jgross-h/coq-8.9-daily" }
 
     env: ${{ matrix.env }}
 

--- a/.github/workflows/docker-coq.yml
+++ b/.github/workflows/docker-coq.yml
@@ -17,7 +17,7 @@ jobs:
       uses: coq-community/docker-coq-action@v1
       with:
         coq_version: dev
-        ocaml_version: 4.13-flambda
+        ocaml_version: default
         custom_script: |
           sudo chmod -R a+rw .
           echo '::group::install general dependencies'

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ _CoqProject: _CoqProject.in
 ifneq (,$(wildcard .git/))
 SORT_COQPROJECT = sed 's,[^/]*/,~&,g' | env LC_COLLATE=C sort | sed 's,~,,g'
 EXISTING_COQPROJECT_CONTENTS_SORTED:=$(shell cat _CoqProject.in 2>&1 | $(SORT_COQPROJECT))
-WARNINGS := +implicit-core-hint-db,+implicits-in-term,+non-reversible-notation,+deprecated-intros-until-0,+deprecated-focus,+unused-intro-pattern,+deprecated-hint-constr,+fragile-hint-constr,+variable-collision,+unexpected-implicit-declaration,+omega-is-deprecated,+non-recursive
+WARNINGS_PLUS := +implicit-core-hint-db,+implicits-in-term,+non-reversible-notation,+deprecated-intros-until-0,+deprecated-focus,+unused-intro-pattern,+deprecated-hint-constr,+fragile-hint-constr,+variable-collision,+unexpected-implicit-declaration,+omega-is-deprecated,+deprecated-instantiate-syntax,+non-recursive,+deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality,+undeclared-scope,+deprecated-typeclasses-transparency-without-locality
+# Remove unsupported-attributes once we stop supporting < 8.14
+WARNINGS := $(WARNINGS_PLUS),unsupported-attributes
 COQPROJECT_CMD:=(echo @META@; echo '-R $(SRC_DIR) $(MOD_NAME)'; echo '-I $(PLUGINS_DIR)'; echo '-arg -w -arg $(WARNINGS)'; echo '@NATIVE_COMPILER_ARG@'; (git ls-files '$(SRC_DIR)/*.v' '$(SRC_DIR)/*.mlg' '$(SRC_DIR)/*.mllib' '$(SRC_DIR)/*.ml' '$(SRC_DIR)/*.mli' | $(SORT_COQPROJECT)); (echo '$(COMPATIBILITY_FILES_PATTERN)' | tr ' ' '\n'))
 NEW_COQPROJECT_CONTENTS_SORTED:=$(shell $(COQPROJECT_CMD) | $(SORT_COQPROJECT))
 

--- a/Makefile.local
+++ b/Makefile.local
@@ -1,6 +1,5 @@
 PROFILE?=
-# Remove -undeclared-scope once we stop supporting 8.9
-OTHERFLAGS += -w -notation-overridden,-undeclared-scope,-deprecated-hint-rewrite-without-locality
+OTHERFLAGS += -w -notation-overridden,-unusable-identifier
 ifneq ($(PROFILE),)
 OTHERFLAGS += -profile-ltac
 endif

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Building
 -----
 [![CI (Coq)](https://github.com/mit-plv/rewriter/actions/workflows/coq.yml/badge.svg?branch=master)](https://github.com/mit-plv/rewriter/actions/workflows/coq.yml?query=branch%3Amaster)
 
-This repository requires Coq 8.9 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
+This repository requires Coq 8.11 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
 
 Git submodules are used for some dependencies. If you did not clone with `--recursive`, run
 

--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -1,7 +1,7 @@
 @META@
 -R src/Rewriter Rewriter
 -I src/Rewriter/Util/plugins
--arg -w -arg +implicit-core-hint-db,+implicits-in-term,+non-reversible-notation,+deprecated-intros-until-0,+deprecated-focus,+unused-intro-pattern,+deprecated-hint-constr,+fragile-hint-constr,+variable-collision,+unexpected-implicit-declaration,+omega-is-deprecated,+non-recursive
+-arg -w -arg +implicit-core-hint-db,+implicits-in-term,+non-reversible-notation,+deprecated-intros-until-0,+deprecated-focus,+unused-intro-pattern,+deprecated-hint-constr,+fragile-hint-constr,+variable-collision,+unexpected-implicit-declaration,+omega-is-deprecated,+deprecated-instantiate-syntax,+non-recursive,+deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality,+undeclared-scope,+deprecated-typeclasses-transparency-without-locality,unsupported-attributes
 @NATIVE_COMPILER_ARG@
 src/Rewriter/Demo.v
 src/Rewriter/Language/IdentifiersBasicGenerate.v
@@ -105,9 +105,7 @@ src/Rewriter/Util/Tactics/Test.v
 src/Rewriter/Util/Tactics/TransparentAssert.v
 src/Rewriter/Util/Tactics/UniquePose.v
 src/Rewriter/Util/Tactics/WarnIfGoalsRemain.v
-src/Rewriter/Util/plugins/RewriterBuild.v
 src/Rewriter/Util/plugins/RewriterBuildRegistryImports.v
-src/Rewriter/Util/plugins/StrategyTactic.v
 src/Rewriter/Util/plugins/definition_by_tactic.ml
 src/Rewriter/Util/plugins/definition_by_tactic.mli
 src/Rewriter/Util/plugins/definition_by_tactic_plugin.@ML4_OR_MLG@
@@ -125,3 +123,5 @@ src/Rewriter/Util/plugins/strategy_tactic.mli
 src/Rewriter/Util/plugins/strategy_tactic_plugin.@ML4_OR_MLG@
 src/Rewriter/Util/plugins/strategy_tactic_plugin.mllib
 src/Rewriter/Util/plugins/RewriterBuildRegistry.v
+src/Rewriter/Util/plugins/StrategyTactic.v
+src/Rewriter/Util/plugins/RewriterBuild.v

--- a/src/Rewriter/Language/Language.v
+++ b/src/Rewriter/Language/Language.v
@@ -307,7 +307,7 @@ Module Compilers.
 
     Class try_make_transport_cpsT {base : Type}
       := try_make_transport_cpsv : forall (P : base -> Type) t1 t2, ~> option (P t1 -> P t2).
-    Hint Mode try_make_transport_cpsT ! : typeclass_instances.
+    #[global] Hint Mode try_make_transport_cpsT ! : typeclass_instances.
     Global Arguments try_make_transport_cpsT : clear implicits.
 
     Class try_make_transport_cps_correctT {base : Type}
@@ -323,7 +323,7 @@ Module Compilers.
                  | right _ => None
                  end.
 
-    Hint Mode try_make_transport_cps_correctT ! - - - : typeclass_instances.
+    #[global] Hint Mode try_make_transport_cps_correctT ! - - - : typeclass_instances.
     Global Arguments try_make_transport_cps_correctT base {_ _ _}.
 
     Section transport_cps.
@@ -397,6 +397,7 @@ Module Compilers.
       end.
   End type.
   Notation type := type.type.
+  Declare Scope etype_scope.
   Delimit Scope etype_scope with etype.
   Bind Scope etype_scope with type.type.
   Global Arguments type.base {_} _%etype.
@@ -553,6 +554,8 @@ Module Compilers.
       Notation type := type.type.
 
       Module Notations.
+        Declare Scope pbtype_scope.
+        Declare Scope ptype_scope.
         Bind Scope pbtype_scope with type.type.
         Delimit Scope ptype_scope with ptype.
         Delimit Scope pbtype_scope with pbtype.
@@ -1026,6 +1029,9 @@ Module Compilers.
     Qed.
 
     Module Export Notations.
+      Declare Scope expr_scope.
+      Declare Scope Expr_scope.
+      Declare Scope expr_pat_scope.
       Delimit Scope expr_scope with expr.
       Delimit Scope Expr_scope with Expr.
       Delimit Scope expr_pat_scope with expr_pat.
@@ -1372,6 +1378,7 @@ Module Compilers.
              end.
 
     Module Export Notations.
+      Declare Scope ident_scope.
       Delimit Scope ident_scope with ident.
       Global Arguments expr.Ident {base_type%type ident%function var%function t%etype} idc%ident.
       Notation "# x" := (expr.Ident x) (only parsing) : expr_pat_scope.

--- a/src/Rewriter/Language/UnderLetsProofs.v
+++ b/src/Rewriter/Language/UnderLetsProofs.v
@@ -144,9 +144,9 @@ Module Compilers.
     End with_ident.
   End SubstVarLike.
 
-  Hint Resolve SubstVarLike.Wf_SubstVar SubstVarLike.Wf_SubstVarLike SubstVarLike.Wf_SubstVarOrIdent : wf.
-  Hint Opaque SubstVarLike.SubstVar SubstVarLike.SubstVarLike SubstVarLike.SubstVarOrIdent : wf interp rewrite.
-  Hint Rewrite @SubstVarLike.Interp_SubstVar @SubstVarLike.Interp_SubstVarLike @SubstVarLike.Interp_SubstVarOrIdent : interp.
+  #[global] Hint Resolve SubstVarLike.Wf_SubstVar SubstVarLike.Wf_SubstVarLike SubstVarLike.Wf_SubstVarOrIdent : wf.
+  #[global] Hint Opaque SubstVarLike.SubstVar SubstVarLike.SubstVarLike SubstVarLike.SubstVarOrIdent : wf interp rewrite.
+  #[global] Hint Rewrite @SubstVarLike.Interp_SubstVar @SubstVarLike.Interp_SubstVarLike @SubstVarLike.Interp_SubstVarOrIdent : interp.
 
   Module UnderLets.
     Import UnderLets.Compilers.UnderLets.
@@ -2009,7 +2009,7 @@ Module Compilers.
     End reify.
   End UnderLets.
 
-  Hint Resolve UnderLets.Wf_LetBindReturn : wf.
-  Hint Opaque UnderLets.LetBindReturn : wf interp rewrite.
-  Hint Rewrite @UnderLets.Interp_LetBindReturn : interp.
+  #[global] Hint Resolve UnderLets.Wf_LetBindReturn : wf.
+  #[global] Hint Opaque UnderLets.LetBindReturn : wf interp rewrite.
+  #[global] Hint Rewrite @UnderLets.Interp_LetBindReturn : interp.
 End Compilers.

--- a/src/Rewriter/Language/Wf.v
+++ b/src/Rewriter/Language/Wf.v
@@ -37,10 +37,10 @@ Module Compilers.
 
   Create HintDb wf discriminated.
   Create HintDb interp discriminated.
-  Hint Constants Opaque : wf interp.
+  #[global] Hint Constants Opaque : wf interp.
 
-  Hint Opaque expr.interp expr.Interp : interp rewrite.
-  Hint Extern 2 => typeclasses eauto : wf.
+  #[global] Hint Opaque expr.interp expr.Interp : interp rewrite.
+  #[global] Hint Extern 2 => typeclasses eauto : wf.
 
   Module type.
     Section eqv.
@@ -63,7 +63,7 @@ Module Compilers.
       Local Instance related_Symmetric {t} {R : forall t, relation (interp_base_type t)}
              {R_sym : forall t, Symmetric (R t)}
         : Symmetric (@type.related base_type interp_base_type R t) | 100.
-      Proof.
+      Proof using Type.
         cbv [Symmetric] in *;
           induction t; cbn [type.related type.interp] in *; repeat intro; eauto.
       Qed.
@@ -72,7 +72,7 @@ Module Compilers.
             {R_sym : forall t, Symmetric (R t)}
             {R_trans : forall t, Transitive (R t)}
         : Transitive (@type.related base_type interp_base_type R t) | 100.
-      Proof.
+      Proof using Type.
         induction t; cbn [type.related]; [ exact _ | ].
         cbv [respectful]; cbn [type.interp].
         intros f g h Hfg Hgh x y Hxy.
@@ -216,9 +216,9 @@ Module Compilers.
         Proof using R_sym R_trans. t. Qed.
       End proper.
     End eqv.
-    Hint Extern 100 (Symmetric (@type.related ?base_type ?interp_base_type ?R ?t))
+    #[global] Hint Extern 100 (Symmetric (@type.related ?base_type ?interp_base_type ?R ?t))
     => (tryif has_evar R then fail else simple apply (@related_Symmetric base_type interp_base_type t R)) : typeclass_instances.
-    Hint Extern 100 (Transitive (@type.related ?base_type ?interp_base_type ?R ?t))
+    #[global] Hint Extern 100 (Transitive (@type.related ?base_type ?interp_base_type ?R ?t))
     => (tryif has_evar R then fail else simple apply (@related_Transitive base_type interp_base_type t R)) : typeclass_instances.
 
     Section app_curried_instances.
@@ -230,30 +230,30 @@ Lemma PER_valid_l {A} {R : relation A} {HS : Symmetric R} {HT : Transitive R} x 
 Proof. hnf; etransitivity; eassumption || symmetry; eassumption. Qed.
 Lemma PER_valid_r {A} {R : relation A} {HS : Symmetric R} {HT : Transitive R} x y (H : R x y) : Proper R y.
 Proof. hnf; etransitivity; eassumption || symmetry; eassumption. Qed.
-Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_l _ R); [ | | solve [ eauto with nocore ] ] : typeclass_instances.
-Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [ eauto with nocore ] ] : typeclass_instances.
+#[global] Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_l _ R); [ | | solve [ eauto with nocore ] ] : typeclass_instances.
+#[global] Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [ eauto with nocore ] ] : typeclass_instances.
 >>
 *)
       Global Instance app_curried_Proper_gen {R t}
         : Proper (@type.related base_type base_interp R t ==> type.and_for_each_lhs_of_arrow (@type.related base_type base_interp R)  ==> R (type.final_codomain t))
                  (@type.app_curried base_type base_interp t) | 1.
-      Proof.
+      Proof using Type.
         cbv [Proper respectful]; induction t; cbn [type.related type.app_curried]; cbv [Proper respectful]; [ intros; assumption | ].
         intros f g Hfg x y [Hxy ?]; eauto.
       Qed.
       Lemma app_curried_Proper {t}
         : Proper (@type.related base_type base_interp (fun _ => eq) t ==> type.and_for_each_lhs_of_arrow (@type.eqv) ==> eq)
                  (@type.app_curried base_type base_interp t).
-      Proof. exact _. Qed.
+      Proof using Type. exact _. Qed.
       Global Instance and_for_each_lhs_of_arrow_Reflexive {f} {R} {_ : forall t, Reflexive (R t)} {t}
         : Reflexive (@type.and_for_each_lhs_of_arrow base_type f f R t) | 1.
-      Proof. cbv [Reflexive] in *; induction t; cbn; repeat split; eauto. Qed.
+      Proof using Type. cbv [Reflexive] in *; induction t; cbn; repeat split; eauto. Qed.
       Global Instance and_for_each_lhs_of_arrow_Symmetric {f} {R} {_ : forall t, Symmetric (R t)} {t}
         : Symmetric (@type.and_for_each_lhs_of_arrow base_type f f R t) | 1.
-      Proof. cbv [Symmetric] in *; induction t; cbn; repeat split; intuition eauto. Qed.
+      Proof using Type. cbv [Symmetric] in *; induction t; cbn; repeat split; intuition eauto. Qed.
       Global Instance and_for_each_lhs_of_arrow_Transitive {f} {R} {_ : forall t, Transitive (R t)} {t}
         : Transitive (@type.and_for_each_lhs_of_arrow base_type f f R t) | 1.
-      Proof. cbv [Transitive] in *; induction t; cbn; repeat split; intuition eauto. Qed.
+      Proof using Type. cbv [Transitive] in *; induction t; cbn; repeat split; intuition eauto. Qed.
     End app_curried_instances.
 
     Lemma and_eqv_for_each_lhs_of_arrow_not_higher_order {base_type base_interp t}
@@ -772,7 +772,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
     Global Hint Constructors wf : wf.
     Global Hint Resolve Wf_APP : wf.
     Global Hint Opaque expr.APP : wf interp rewrite.
-    Hint Rewrite @expr.Interp_APP : interp.
+    #[global] Hint Rewrite @expr.Interp_APP : interp.
 
     Ltac is_expr_constructor arg :=
       lazymatch arg with
@@ -819,7 +819,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
             t e1 e2
             (Hwf : @wf var1 var2 G1 t e1 e2)
         : @wf var2 var1 G2 t e2 e1.
-      Proof.
+      Proof using Type.
         revert dependent G2; induction Hwf; constructor;
           repeat first [ progress cbn in *
                        | solve [ eauto ]
@@ -836,7 +836,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
             t e1 e2
             (Hwf : @wf var1 var2 G1 t e1 e2)
         : @wf var1 var2 G2 t e1 e2.
-      Proof.
+      Proof using Type.
         revert dependent G2; induction Hwf; constructor;
           repeat first [ progress cbn in *
                        | progress intros
@@ -852,7 +852,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
             t e1 e2
         : @wf var2 var1 (List.map (fun '(existT t (v1, v2)) => existT _ t (v2, v1)) G) t e2 e1
           <-> @wf var1 var2 G t e1 e2.
-      Proof.
+      Proof using Type.
         split; apply wf_sym; intros ???; rewrite in_map_iff;
           intros; destruct_head'_ex; destruct_head'_sigT; destruct_head_prod; destruct_head'_and; inversion_sigma; inversion_prod; subst.
         { assumption. }
@@ -908,7 +908,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
             (Hwf2 : @wf var2 _ G2 t e2 e123)
             (Hwf3 : @wf var3 _ G3 t e3 e123)
         : @wf3 base_type ident var1 var2 var3 G t e1 e2 e3.
-      Proof.
+      Proof using Type.
         subst G2 G3; revert dependent e3; revert dependent e2; revert dependent G; induction Hwf1; intros.
         Time all: repeat first [ progress subst
                                | progress cbn [projT1 projT2 fst snd eq_rect] in *
@@ -944,7 +944,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
             e1 e2 e3
             (Hwf : @wf3 base_type ident var1 var2 var2 G t e1 e2 e3)
         : @wf _ _ G1 t e1 e2.
-      Proof.
+      Proof using Type.
         subst G1 G2.
         induction Hwf; cbn [map] in *; constructor; rewrite ?in_map_iff; intros;
           try eexists (existT (fun t => _ * _ * _)%type _ (_, _, _));
@@ -954,13 +954,13 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
       Qed.
 
       Lemma Wf_of_Wf3 {t} (e : expr.Expr t) : @Wf3 base_type ident t e -> @Wf base_type ident t e.
-      Proof. intros Hwf var1 var2; eapply wf_of_wf3 with (G:=nil), Hwf. Qed.
+      Proof using Type. intros Hwf var1 var2; eapply wf_of_wf3 with (G:=nil), Hwf. Qed.
 
       Lemma Wf3_of_Wf {t} (e : expr.Expr t) : @Wf base_type ident t e -> @Wf3 base_type ident t e.
-      Proof. intros Hwf var1 var2 var3; eapply wf3_of_wf with (G:=nil); try eapply Hwf; reflexivity. Qed.
+      Proof using Type. intros Hwf var1 var2 var3; eapply wf3_of_wf with (G:=nil); try eapply Hwf; reflexivity. Qed.
 
       Lemma Wf_iff_Wf3 {t} (e : expr.Expr t) : @Wf base_type ident t e <-> @Wf3 base_type ident t e.
-      Proof. split; (apply Wf_of_Wf3 + apply Wf3_of_Wf). Qed.
+      Proof using Type. split; (apply Wf_of_Wf3 + apply Wf3_of_Wf). Qed.
     End wf_properties.
     Global Hint Immediate Wf_of_Wf3 : wf.
     Global Hint Resolve Wf3_of_Wf : wf.
@@ -980,7 +980,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
               (Hwf : @wf _ _ _ _ G t e1 e2)
               (HG : forall t v1 v2, In (existT _ t (v1, v2)) G -> type.related R v1 v2)
           : type.related R (expr.interp ident_interp1 e1) (expr.interp ident_interp2 e2).
-        Proof.
+        Proof using ident_interp_Proper.
           induction Hwf;
             repeat first [ reflexivity
                          | assumption
@@ -1013,14 +1013,14 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
         Lemma wf_interp_Proper_gen1 G {t}
               (HG : forall t v1 v2, In (existT _ t (v1, v2)) G -> type.related R v1 v2)
           : Proper (@wf _ _ _ _ G t ==> type.related R) (expr.interp ident_interp).
-        Proof. intros ? ? Hwf; eapply @wf_interp_Proper_gen2; eassumption. Qed.
+        Proof using ident_interp_Proper. intros ? ? Hwf; eapply @wf_interp_Proper_gen2; eassumption. Qed.
 
         Lemma wf_interp_Proper_gen {t}
           : Proper (@wf _ _ _ _ nil t ==> type.related R) (expr.interp ident_interp).
-        Proof. apply wf_interp_Proper_gen1; cbn [In]; tauto. Qed.
+        Proof using ident_interp_Proper. apply wf_interp_Proper_gen1; cbn [In]; tauto. Qed.
 
         Lemma Wf_Interp_Proper_gen {t} (e : expr.Expr t) : Wf e -> Proper (type.related R) (expr.Interp ident_interp e).
-        Proof. intro Hwf; apply wf_interp_Proper_gen, Hwf. Qed.
+        Proof using ident_interp_Proper. intro Hwf; apply wf_interp_Proper_gen, Hwf. Qed.
       End with_1.
     End interp_gen.
 
@@ -1358,16 +1358,16 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
       End with_var2.
 
       Lemma Wf_base_Reify_as {t} v : expr.Wf (GallinaReify.base.Reify_as t v).
-      Proof. repeat intro; apply wf_reify. Qed.
+      Proof using reflect_base_beq. repeat intro; apply wf_reify. Qed.
 
       Lemma Wf_Reify_as {t} (v : base.interp base_interp t) : expr.Wf (GallinaReify.Reify_as (type.base t) (fun _ => v)).
-      Proof. repeat intro; apply wf_reify. Qed.
+      Proof using reflect_base_beq. repeat intro; apply wf_reify. Qed.
 
       Lemma Wf_base_reify {t} v : expr.Wf (fun var => GallinaReify.base.reify (t:=t) v).
-      Proof. repeat intro; apply wf_reify. Qed.
+      Proof using reflect_base_beq. repeat intro; apply wf_reify. Qed.
 
       Lemma Wf_reify {t} (v : base.interp base_interp t) : expr.Wf (fun var => GallinaReify.reify (t:=type.base t) v).
-      Proof. repeat intro; apply wf_reify. Qed.
+      Proof using reflect_base_beq. repeat intro; apply wf_reify. Qed.
 
       Section interp.
         Context {ident_interp : forall t, ident t -> type.interp (base.interp base_interp) t}.
@@ -1420,10 +1420,10 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
 
         Lemma reify_interp_related {t} v
           : expr_interp_related (GallinaReify.base.reify (t:=t) v) v.
-        Proof. apply smart_Literal_interp_related. Qed.
+        Proof using buildInterpIdentCorrect. apply smart_Literal_interp_related. Qed.
 
         Lemma interp_reify {t} v : interp (GallinaReify.base.reify (t:=t) v) = v.
-        Proof.
+        Proof using buildInterpIdentCorrect.
           pose proof (@reify_interp_related t v) as H.
           eapply eqv_of_interp_related in H; assumption.
         Qed.
@@ -1437,13 +1437,13 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
 
         Lemma Reify_as_interp_related {t} v
           : expr_interp_related (GallinaReify.base.Reify_as t v _) v.
-        Proof. apply reify_interp_related. Qed.
+        Proof using buildInterpIdentCorrect. apply reify_interp_related. Qed.
 
         Lemma Interp_Reify_as {t} v : expr.Interp ident_interp (GallinaReify.base.Reify_as t v) = v.
-        Proof. apply interp_reify. Qed.
+        Proof using buildInterpIdentCorrect. apply interp_reify. Qed.
 
         Lemma Interp_reify {t} v : expr.Interp ident_interp (fun var => GallinaReify.base.reify (t:=t) v) = v.
-        Proof. apply interp_reify. Qed.
+        Proof using buildInterpIdentCorrect. apply interp_reify. Qed.
       End interp.
     End invert.
 
@@ -1453,16 +1453,16 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
     Notation Interp_Reify := Interp_Reify_as.
   End expr.
 
-  Hint Constructors expr.wf : wf.
-  Hint Resolve expr.Wf_APP expr.Wf_Reify expr.Wf_reify expr.Wf_base_Reify expr.Wf_base_reify : wf.
+  #[global] Hint Constructors expr.wf : wf.
+  #[global] Hint Resolve expr.Wf_APP expr.Wf_Reify expr.Wf_reify expr.Wf_base_Reify expr.Wf_base_reify : wf.
   (** Work around COQBUG(https://github.com/coq/coq/issues/11536) *)
-  Hint Extern 1 (expr.Wf (GallinaReify.base.Reify_as _ _)) => simple apply (@expr.Wf_base_Reify) : wf.
-  Hint Extern 1 (expr.Wf (GallinaReify.Reify_as _ _)) => simple apply (@expr.Wf_Reify) : wf.
+  #[global] Hint Extern 1 (expr.Wf (GallinaReify.base.Reify_as _ _)) => simple apply (@expr.Wf_base_Reify) : wf.
+  #[global] Hint Extern 1 (expr.Wf (GallinaReify.Reify_as _ _)) => simple apply (@expr.Wf_Reify) : wf.
   (** Work around COQBUG(https://github.com/coq/coq/issues/11536) *)
-  Hint Extern 1 (expr.Wf (fun var => GallinaReify.base.reify _)) => simple apply (@expr.Wf_base_reify) : wf.
-  Hint Extern 1 (expr.Wf (fun var => GallinaReify.reify _)) => simple apply (@expr.Wf_reify) : wf.
-  Hint Opaque expr.APP GallinaReify.Reify_as GallinaReify.base.reify : wf interp rewrite.
-  Hint Rewrite @expr.Interp_Reify @expr.interp_reify @expr.interp_reify_list @expr.interp_reify_option @expr.Interp_reify @expr.Interp_APP : interp.
+  #[global] Hint Extern 1 (expr.Wf (fun var => GallinaReify.base.reify _)) => simple apply (@expr.Wf_base_reify) : wf.
+  #[global] Hint Extern 1 (expr.Wf (fun var => GallinaReify.reify _)) => simple apply (@expr.Wf_reify) : wf.
+  #[global] Hint Opaque expr.APP GallinaReify.Reify_as GallinaReify.base.reify : wf interp rewrite.
+  #[global] Hint Rewrite @expr.Interp_Reify @expr.interp_reify @expr.interp_reify_list @expr.interp_reify_option @expr.Interp_reify @expr.Interp_APP : interp.
 
   Notation Wf := expr.Wf.
 
@@ -1623,13 +1623,13 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
             Context {var1 var2 : type -> Type}.
 
             Lemma wf_default G {t : base_type} : expr.wf (var1:=var1) (var2:=var2) (t:=type.base t) G expr.base.default expr.base.default.
-            Proof.
+            Proof using Type.
               induction t; wf_t.
             Qed.
           End with_var2.
 
           Lemma Wf_Default {t : base_type} : Wf (t:=type.base t) expr.base.Default.
-          Proof. repeat intro; apply @wf_default. Qed.
+          Proof using Type. repeat intro; apply @wf_default. Qed.
         End with_base.
       End base.
 
@@ -1644,9 +1644,9 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
                 {buildIdent : @ident.BuildIdentT base base_interp ident}.
 
         Global Instance wf_default : @ExprDefault_wfT base_type ident _.
-        Proof. intros var1 var2 G t; revert G; induction t; intros; wf_t; apply base.wf_default. Qed.
+        Proof using Type. intros var1 var2 G t; revert G; induction t; intros; wf_t; apply base.wf_default. Qed.
         Global Instance Wf_Default : @ExprDefault_WfT base_type ident _.
-        Proof. repeat intro; apply @wf_default. Qed.
+        Proof using Type. repeat intro; apply @wf_default. Qed.
       End with_base.
     End expr.
   End DefaultValue.
@@ -1768,7 +1768,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
                                  /\ List.In (existT _ t (v1', v2)) G2)
               (Hoffset : forall p, PositiveMap.find p ctx <> None -> (p < offset)%positive)
           : expr.wf G2 (var2:=var2) (from_flat (to_flat' (t:=t) e1 offset) var1 ctx) e2.
-        Proof.
+        Proof using try_make_transport_base_type_cps_correct.
           revert dependent offset; revert dependent G2; revert dependent ctx; induction Hwf; intros.
           all: repeat first [ progress cbn [from_flat to_flat' List.In projT1 projT2 fst snd] in *
                             | progress intros
@@ -1807,12 +1807,12 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
       End with_var.
 
       Lemma Wf_FromFlat {t} (e : Flat_expr t) : Flat.wf (base_type_beq:=base_type_beq) (PositiveMap.empty _) e = true -> expr.Wf (FromFlat e).
-      Proof. intros H ??; apply wf_from_flat, H. Qed.
+      Proof using try_make_transport_base_type_cps_correct. intros H ??; apply wf_from_flat, H. Qed.
 
       Lemma Wf_via_flat {t} (e : Expr t)
         : (e = GeneralizeVar (e _) /\ Flat.wf (base_type_beq:=base_type_beq) (PositiveMap.empty _) (to_flat (e _)) = true)
           -> expr.Wf e.
-      Proof. intros [H0 H1]; rewrite H0; cbv [GeneralizeVar]; apply Wf_FromFlat, H1. Qed.
+      Proof using try_make_transport_base_type_cps_correct. intros [H0 H1]; rewrite H0; cbv [GeneralizeVar]; apply Wf_FromFlat, H1. Qed.
 
       Lemma wf_to_flat'_gen
             {t}
@@ -1884,14 +1884,14 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
       Qed.
 
       Lemma Wf_ToFlat {t} (e : Expr (ident:=ident) t) (Hwf : expr.Wf e) : Flat.wf (base_type_beq:=base_type_beq) (PositiveMap.empty _) (ToFlat e) = true.
-      Proof. eapply wf_to_flat, Hwf. Qed.
+      Proof using try_make_transport_base_type_cps_correct. eapply wf_to_flat, Hwf. Qed.
 
       Lemma Wf_FromFlat_to_flat {t} (e : expr t) : expr.wf (ident:=ident) nil e e -> expr.Wf (FromFlat (to_flat e)).
-      Proof. intro Hwf; eapply Wf_FromFlat, wf_to_flat, Hwf. Qed.
+      Proof using try_make_transport_base_type_cps_correct. intro Hwf; eapply Wf_FromFlat, wf_to_flat, Hwf. Qed.
       Lemma Wf_FromFlat_ToFlat {t} (e : Expr t) : expr.Wf (ident:=ident) e -> expr.Wf (FromFlat (ToFlat e)).
-      Proof. intro H; apply Wf_FromFlat_to_flat, H. Qed.
+      Proof using try_make_transport_base_type_cps_correct. intro H; apply Wf_FromFlat_to_flat, H. Qed.
       Lemma Wf_GeneralizeVar {t} (e : Expr t) : expr.Wf (ident:=ident) e -> expr.Wf (GeneralizeVar (e _)).
-      Proof. apply Wf_FromFlat_ToFlat. Qed.
+      Proof using try_make_transport_base_type_cps_correct. apply Wf_FromFlat_ToFlat. Qed.
 
       Local Ltac t :=
         repeat first [ reflexivity
@@ -1954,7 +1954,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
 
         Lemma Interp_gen2_GeneralizeVar {t} (e : Expr t) (Hwf : expr.Wf e)
           : type.related R (expr.Interp ident_interp1 (GeneralizeVar (e _))) (expr.Interp ident_interp2 e).
-        Proof. apply Interp_gen2_FromFlat_ToFlat, Hwf. Qed.
+        Proof using ident_interp_Proper try_make_transport_base_type_cps_correct. apply Interp_gen2_FromFlat_ToFlat, Hwf. Qed.
       End gen2.
       Section gen1.
         Context {base_interp : base_type -> Type}
@@ -1970,15 +1970,15 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
               cur_idx
               (Hidx : forall p, PositiveMap.mem p ctx = true -> BinPos.Pos.lt p cur_idx)
           : type.related R (expr.interp ident_interp (from_flat (to_flat' e1 cur_idx) _ ctx)) (expr.interp ident_interp e2).
-        Proof. apply @interp_gen2_from_flat_to_flat' with (G:=G); eassumption. Qed.
+        Proof using ident_interp_Proper try_make_transport_base_type_cps_correct. apply @interp_gen2_from_flat_to_flat' with (G:=G); eassumption. Qed.
 
         Lemma Interp_gen1_FromFlat_ToFlat {t} (e : Expr t) (Hwf : expr.Wf e)
           : type.related R (expr.Interp ident_interp (FromFlat (ToFlat e))) (expr.Interp ident_interp e).
-        Proof. apply @Interp_gen2_FromFlat_ToFlat; eassumption. Qed.
+        Proof using ident_interp_Proper try_make_transport_base_type_cps_correct. apply @Interp_gen2_FromFlat_ToFlat; eassumption. Qed.
 
         Lemma Interp_gen1_GeneralizeVar {t} (e : Expr t) (Hwf : expr.Wf e)
           : type.related R (expr.Interp ident_interp (GeneralizeVar (e _))) (expr.Interp ident_interp e).
-        Proof. apply @Interp_gen2_GeneralizeVar; eassumption. Qed.
+        Proof using ident_interp_Proper try_make_transport_base_type_cps_correct. apply @Interp_gen2_GeneralizeVar; eassumption. Qed.
       End gen1.
     End with_base_type.
   End GeneralizeVar.
@@ -1999,7 +1999,7 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
   Ltac prove_Wf3 _ := prove_Wf3_with ltac:(fun _ => idtac).
 
   Global Hint Extern 0 (?x == ?x) => apply expr.Wf_Interp_Proper_gen : wf interp.
-  Hint Resolve GeneralizeVar.Wf_FromFlat_ToFlat GeneralizeVar.Wf_GeneralizeVar : wf.
-  Hint Opaque GeneralizeVar.FromFlat GeneralizeVar.ToFlat GeneralizeVar.GeneralizeVar : wf interp rewrite.
-  Hint Rewrite @GeneralizeVar.Interp_gen1_GeneralizeVar @GeneralizeVar.Interp_gen1_FromFlat_ToFlat : interp.
+  #[global] Hint Resolve GeneralizeVar.Wf_FromFlat_ToFlat GeneralizeVar.Wf_GeneralizeVar : wf.
+  #[global] Hint Opaque GeneralizeVar.FromFlat GeneralizeVar.ToFlat GeneralizeVar.GeneralizeVar : wf interp rewrite.
+  #[global] Hint Rewrite @GeneralizeVar.Interp_gen1_GeneralizeVar @GeneralizeVar.Interp_gen1_FromFlat_ToFlat : interp.
 End Compilers.

--- a/src/Rewriter/Rewriter/Examples/PerfTesting/Harness.v
+++ b/src/Rewriter/Rewriter/Examples/PerfTesting/Harness.v
@@ -282,10 +282,10 @@ Proof.
   intros x y; specialize (Hr x y); destruct Hr; intuition (eauto; congruence).
 Qed.
 
-Instance reflect_eq_nat : reflect_rel (@eq nat) Nat.eqb
+Global Instance reflect_eq_nat : reflect_rel (@eq nat) Nat.eqb
   := reflect_rel_of_beq_iff Nat.eqb_eq.
 
-Instance reflect_eq_Z : reflect_rel (@eq Z) Z.eqb
+Global Instance reflect_eq_Z : reflect_rel (@eq Z) Z.eqb
   := reflect_rel_of_beq_iff Z.eqb_eq.
 
 Local Set Implicit Arguments.
@@ -301,25 +301,25 @@ Proof.
 Defined.
 Local Unset Implicit Arguments.
 
-Instance reflect_eq_prod {A B eqA eqB} {_ : reflect_rel (@eq A) eqA} {_ : reflect_rel (@eq B) eqB}
+Global Instance reflect_eq_prod {A B eqA eqB} {_ : reflect_rel (@eq A) eqA} {_ : reflect_rel (@eq B) eqB}
   : reflect_rel (@eq (A * B)) (prod_beq eqA eqB)
   := reflect_rel_of_beq_iff (prod_beq_iff (reflect_rel_to_beq_iff _) (reflect_rel_to_beq_iff _)).
 
 Class has_sub T := sub : T -> T -> T.
-Instance: has_sub nat := Nat.sub.
-Instance: has_sub Z := Z.sub.
+Global Instance: has_sub nat := Nat.sub.
+Global Instance: has_sub Z := Z.sub.
 
 Class has_succ T := succ : T -> T.
-Instance: has_succ nat := S.
-Instance: has_succ Z := Z.succ.
+Global Instance: has_succ nat := S.
+Global Instance: has_succ Z := Z.succ.
 
 Class has_zero T := zero : T.
-Instance: has_zero nat := O.
-Instance: has_zero Z := Z0.
+Global Instance: has_zero nat := O.
+Global Instance: has_zero Z := Z0.
 
 Class has_sort T := sort : list T -> list T.
-Instance: has_sort nat := NatSort.sort.
-Instance: has_sort Z := ZSort.sort.
+Global Instance: has_sort nat := NatSort.sort.
+Global Instance: has_sort Z := ZSort.sort.
 
 Definition remove_smaller_args_of_size_by_reflect
            {T} {T_beq : T -> T -> bool}

--- a/src/Rewriter/Rewriter/Examples/PerfTesting/LiftLetsMap.v
+++ b/src/Rewriter/Rewriter/Examples/PerfTesting/LiftLetsMap.v
@@ -63,10 +63,10 @@ Definition make_cps {T} (n : nat) (m : nat) (v : Z) (k : list Z -> T)
 Lemma lift_let_list_rect T A P N C (v : A) fls
   : @list_rect T P N C (Let_In v fls) = Let_In v (fun v => @list_rect T P N C (fls v)).
 Proof. reflexivity. Qed.
-Hint Rewrite lift_let_list_rect : mydb2.
+#[global] Hint Rewrite lift_let_list_rect : mydb2.
 Lemma lift_let_cons T A x (v : A) f : @cons T x (Let_In v f) = Let_In v (fun v => @cons T x (f v)).
 Proof. reflexivity. Qed.
-Hint Rewrite lift_let_cons : mydb1.
+#[global] Hint Rewrite lift_let_cons : mydb1.
 
 Lemma eval_repeat
   : forall A x n,

--- a/src/Rewriter/Rewriter/Examples/PerfTesting/Plus0Tree.v
+++ b/src/Rewriter/Rewriter/Examples/PerfTesting/Plus0Tree.v
@@ -417,7 +417,7 @@ Ltac describe_goal nm :=
        idtac "Params: 0-nm=" sz ", 1-n=" n ", 2-m=" m ", 3-input-size=" input_num_nodes ", 4-output-size=" output_num_nodes ", 5-num-rewrites=" num_rewrites
   end.
 
-Hint Rewrite Z.add_0_r : mydb.
+#[global] Hint Rewrite Z.add_0_r : mydb.
 
 Ltac do_coq_rewrite _ := rewrite -> !Z.add_0_r.
 
@@ -503,7 +503,7 @@ Ltac mkgoal6 := mkgoal constr:(kind_rewrite_lhs_for).
 Ltac time_solve_goal6 := time_solve_goal constr:(kind_rewrite_lhs_for).
 Ltac run6 sz := Harness.runtests_verify_sanity (args_of_size (kind_rewrite_lhs_for)) describe_goal mkgoal6 redgoal time_solve_goal6 verify sz.
 
-Hint Opaque Z.add : rewrite typeclass_instances.
+#[global] Hint Opaque Z.add : rewrite typeclass_instances.
 
 Global Instance : forall {A}, Proper (eq ==> eq ==> Basics.flip Basics.impl) (@eq A) := _.
 Global Instance : Proper (eq ==> eq ==> eq) Z.add := _.

--- a/src/Rewriter/Rewriter/Examples/PerfTesting/Sample.v
+++ b/src/Rewriter/Rewriter/Examples/PerfTesting/Sample.v
@@ -677,7 +677,7 @@ Class factors_through_prod {T} (f : N * N -> T) :=
     ; factor_correctness : forall x, f x = factor_through_prod (fst x * snd x)%N }.
 Arguments factor_through_prod {T} f {_}.
 
-Hint Unfold id : solve_factors_through_prod.
+#[global] Hint Unfold id : solve_factors_through_prod.
 
 Ltac subst_context_vars f :=
   let run := match goal with
@@ -753,10 +753,10 @@ Definition small_table (* the [n]th element is the number of ways there are to w
          => (n:N, ∑_{i=1}^{n} if (n mod i =? 0) then 1 else 0)%Z)
         (seq 0 (Z.to_nat (1 + cutoff))).
 
-Hint Extern 0 (reified ?f) => let v := reify_poly f in exact v : typeclass_instances.
+#[global] Hint Extern 0 (reified ?f) => let v := reify_poly f in exact v : typeclass_instances.
 
-Hint Extern 0 (factors_through_prod _) => solve_factors_through_prod : typeclass_instances.
-Hint Extern 0 => progress unfold factor_through_prod : typeclass_instances.
+#[global] Hint Extern 0 (factors_through_prod _) => solve_factors_through_prod : typeclass_instances.
+#[global] Hint Extern 0 => progress unfold factor_through_prod : typeclass_instances.
 
 Global Instance nat_has_double_avg : has_double_avg nat
   := { double_T := Nat.mul 2 ; avg_T x y := ((x + y) / 2)%nat }.
@@ -896,21 +896,21 @@ Definition total_time_of_Zpoly
         if (max - min <=? 25)%Z
         then ∑_{i=min}^{max} (size i)
         else f_int max - f_int min.
-Hint Extern 0 (has_total_time Z) => simple eapply @total_time_of_Zpoly : typeclass_instances.
+#[global] Hint Extern 0 (has_total_time Z) => simple eapply @total_time_of_Zpoly : typeclass_instances.
 
 Definition total_time_of_Npoly
        {size : has_size N}
        {p : reified (fun x => size (Z.to_N x))}
   : has_total_time N
   := fun min max => @total_time_of_Zpoly _ p min max.
-Hint Extern 0 (has_total_time N) => simple eapply @total_time_of_Npoly : typeclass_instances.
+#[global] Hint Extern 0 (has_total_time N) => simple eapply @total_time_of_Npoly : typeclass_instances.
 
 Definition total_time_of_nat_poly
        {size : has_size nat}
        {p : reified (fun x => size (N.to_nat (Z.to_N x)))}
   : has_total_time nat
   := fun min max => @total_time_of_Zpoly _ p min max.
-Hint Extern 0 (has_total_time nat) => simple eapply @total_time_of_nat_poly : typeclass_instances.
+#[global] Hint Extern 0 (has_total_time nat) => simple eapply @total_time_of_nat_poly : typeclass_instances.
 
 Fixpoint make_cumulants'
          {T} (add : T -> T -> T) (acc : T) (ls : list T)
@@ -990,7 +990,7 @@ Definition total_time_of_N_prod_poly
        {p : reified (fun x:Z => factor_through_prod size (Z.to_N x))}
   : has_total_time (N * N)
   := dlet cached_table := small_table_rev_cached in total_time_of_N_prod_poly_cached cached_table.
-Hint Extern 0 (has_total_time (N * N)) => simple eapply @total_time_of_N_prod_poly : typeclass_instances.
+#[global] Hint Extern 0 (has_total_time (N * N)) => simple eapply @total_time_of_N_prod_poly : typeclass_instances.
 
 Definition total_time_of_Z_prod_poly_cached
        {size : has_size (Z * Z)}
@@ -1007,7 +1007,7 @@ Definition total_time_of_Z_prod_poly
        {p : reified (fun x => factor_through_prod size' (Z.to_N x))}
   : has_total_time (Z * Z)
   := dlet cached_table := @small_table_rev_cached size' in total_time_of_Z_prod_poly_cached cached_table.
-Hint Extern 0 (has_total_time (Z * Z)) => simple eapply @total_time_of_Z_prod_poly : typeclass_instances.
+#[global] Hint Extern 0 (has_total_time (Z * Z)) => simple eapply @total_time_of_Z_prod_poly : typeclass_instances.
 
 Definition total_time_of_nat_prod_poly_cached
        {size : has_size (nat * nat)}
@@ -1024,11 +1024,11 @@ Definition total_time_of_nat_prod_poly
        {p : reified (fun x => factor_through_prod size' (Z.to_nat x))}
   : has_total_time (nat * nat)
   := dlet cached_table := @small_table_rev_cached size' in total_time_of_nat_prod_poly_cached cached_table.
-Hint Extern 0 (has_total_time (nat * nat)) => simple eapply @total_time_of_nat_prod_poly : typeclass_instances.
+#[global] Hint Extern 0 (has_total_time (nat * nat)) => simple eapply @total_time_of_nat_prod_poly : typeclass_instances.
 
 Class with_assum {T} (v : T) (T' : Type) := val : T'.
 
-Hint Extern 0 (@with_assum ?T ?v ?T') => pose (v : T); change T' : typeclass_instances.
+#[global] Hint Extern 0 (@with_assum ?T ?v ?T') => pose (v : T); change T' : typeclass_instances.
 
 Class has_compress {A B} := compress_T : A -> B.
 Global Arguments has_compress : clear implicits.

--- a/src/Rewriter/Rewriter/Examples/PerfTesting/Settings.v
+++ b/src/Rewriter/Rewriter/Examples/PerfTesting/Settings.v
@@ -3,8 +3,8 @@ Require Import Rewriter.Util.LetIn.
 Require Import Rewriter.Util.plugins.RewriterBuild.
 
 Ltac rewrite_perf_level ::= constr:(5%nat).
-Hint Opaque Let_In : rewrite typeclass_instances.
-Hint Constants Opaque : rewrite.
+#[global] Hint Opaque Let_In : rewrite typeclass_instances.
+#[global] Hint Constants Opaque : rewrite.
 Global Opaque Let_In.
 Global Set Printing Width 150.
 Global Set NativeCompute Timing.

--- a/src/Rewriter/Rewriter/Examples/PerfTesting/UnderLetsPlus0.v
+++ b/src/Rewriter/Rewriter/Examples/PerfTesting/UnderLetsPlus0.v
@@ -46,7 +46,7 @@ Ltac verify _ :=
     => is_var acc; verify_form acc lhs
   end.
 
-Hint Rewrite Z.add_0_r : mydb.
+#[global] Hint Rewrite Z.add_0_r : mydb.
 
 Inductive rewrite_strat_kind := topdown | bottomup.
 Inductive kind_of_rewrite := kind_rewrite_strat (_ : rewrite_strat_kind) | kind_setoid_rewrite | kind_rewrite_lhs_for.
@@ -250,7 +250,7 @@ Ltac run3 sz := Harness.runtests_verify_sanity (args_of_size (kind_rewrite_lhs_f
 
 
 Local Transparent Let_In.
-Hint Opaque Let_In Z.add : rewrite typeclass_instances.
+#[global] Hint Opaque Let_In Z.add : rewrite typeclass_instances.
 Global Opaque Let_In Z.add.
 
 Global Instance : forall {A}, Proper (eq ==> eq ==> Basics.flip Basics.impl) (@eq A) := _.

--- a/src/Rewriter/Rewriter/ProofsCommon.v
+++ b/src/Rewriter/Rewriter/ProofsCommon.v
@@ -958,7 +958,7 @@ Module Compilers.
                | rExpr t e
                | rValue (type.base t) e
                  => e === e1
-               | rValue t e => False
+               | rValue _t _e => False
                end.
 
           Fixpoint rawexpr_equiv (r1 r2 : rawexpr) : Prop
@@ -2377,7 +2377,7 @@ Module Compilers.
                | rExpr _ e1
                | rValue (type.base _) e1
                  => expr_interp_related e1
-               | rValue t1 v1
+               | rValue _t1 v1
                  => value_interp_related v1
                | rIdent _ t1 idc1 t'1 alt1
                  => fun v2

--- a/src/Rewriter/Util/Bool.v
+++ b/src/Rewriter/Util/Bool.v
@@ -30,15 +30,15 @@ Create HintDb bool_congr_setoid discriminated.
 (** For generic simplifications of things involving booleans, e.g., if-statements *)
 Create HintDb boolsimplify discriminated.
 
-Hint Extern 1 => progress autorewrite with boolsimplify in * : boolsimplify.
-Hint Extern 1 => progress autorewrite with bool_congr in * : bool_congr.
-Hint Extern 1 => progress autorewrite with bool_congr_setoid in * : bool_congr_setoid.
-Hint Extern 2 => progress rewrite_strat topdown hints bool_congr_setoid : bool_congr_setoid.
+#[global] Hint Extern 1 => progress autorewrite with boolsimplify in * : boolsimplify.
+#[global] Hint Extern 1 => progress autorewrite with bool_congr in * : bool_congr.
+#[global] Hint Extern 1 => progress autorewrite with bool_congr_setoid in * : bool_congr_setoid.
+#[global] Hint Extern 2 => progress rewrite_strat topdown hints bool_congr_setoid : bool_congr_setoid.
 
-Hint Rewrite Bool.andb_diag Bool.orb_diag Bool.eqb_reflx Bool.negb_involutive Bool.eqb_negb1 Bool.eqb_negb2 Bool.orb_true_r Bool.orb_true_l Bool.orb_false_r Bool.orb_false_l Bool.orb_negb_r Bool.andb_false_r Bool.andb_false_l Bool.andb_true_r Bool.andb_false_r Bool.andb_negb_r Bool.xorb_false_r Bool.xorb_false_l Bool.xorb_true_r Bool.xorb_true_l Bool.xorb_nilpotent : bool_congr.
-Hint Rewrite Bool.negb_if : boolsimplify.
-Hint Rewrite <- Bool.andb_if Bool.andb_lazy_alt Bool.orb_lazy_alt : boolsimplify.
-Hint Rewrite Bool.not_true_iff_false Bool.not_false_iff_true Bool.eqb_true_iff Bool.eqb_false_iff Bool.negb_true_iff Bool.negb_false_iff Bool.orb_true_iff Bool.orb_false_iff Bool.andb_true_iff Bool.andb_false_iff Bool.xorb_negb_negb : bool_congr_setoid.
+#[global] Hint Rewrite Bool.andb_diag Bool.orb_diag Bool.eqb_reflx Bool.negb_involutive Bool.eqb_negb1 Bool.eqb_negb2 Bool.orb_true_r Bool.orb_true_l Bool.orb_false_r Bool.orb_false_l Bool.orb_negb_r Bool.andb_false_r Bool.andb_false_l Bool.andb_true_r Bool.andb_false_r Bool.andb_negb_r Bool.xorb_false_r Bool.xorb_false_l Bool.xorb_true_r Bool.xorb_true_l Bool.xorb_nilpotent : bool_congr.
+#[global] Hint Rewrite Bool.negb_if : boolsimplify.
+#[global] Hint Rewrite <- Bool.andb_if Bool.andb_lazy_alt Bool.orb_lazy_alt : boolsimplify.
+#[global] Hint Rewrite Bool.not_true_iff_false Bool.not_false_iff_true Bool.eqb_true_iff Bool.eqb_false_iff Bool.negb_true_iff Bool.negb_false_iff Bool.orb_true_iff Bool.orb_false_iff Bool.andb_true_iff Bool.andb_false_iff Bool.xorb_negb_negb : bool_congr_setoid.
 
 Create HintDb push_orb discriminated.
 Create HintDb pull_orb discriminated.
@@ -46,23 +46,23 @@ Create HintDb push_andb discriminated.
 Create HintDb pull_andb discriminated.
 Create HintDb push_negb discriminated.
 Create HintDb pull_negb discriminated.
-Hint Extern 1 => progress autorewrite with push_orb in * : push_orb.
-Hint Extern 1 => progress autorewrite with pull_orb in * : pull_orb.
-Hint Extern 1 => progress autorewrite with push_andb in * : push_andb.
-Hint Extern 1 => progress autorewrite with pull_andb in * : pull_andb.
-Hint Extern 1 => progress autorewrite with push_negb in * : push_negb.
-Hint Extern 1 => progress autorewrite with pull_negb in * : pull_negb.
-Hint Rewrite Bool.negb_orb Bool.negb_andb : push_negb.
-Hint Rewrite Bool.xorb_negb_negb : pull_negb.
-Hint Rewrite <- Bool.negb_orb Bool.negb_andb Bool.negb_xorb_l Bool.negb_xorb_r : pull_negb.
-Hint Rewrite Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : push_andb.
-Hint Rewrite <- Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : push_andb.
-Hint Rewrite Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : pull_andb.
-Hint Rewrite <- Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : pull_andb.
-Hint Rewrite Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : push_orb.
-Hint Rewrite <- Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : push_orb.
-Hint Rewrite <- Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : pull_orb.
-Hint Rewrite Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : pull_orb.
+#[global] Hint Extern 1 => progress autorewrite with push_orb in * : push_orb.
+#[global] Hint Extern 1 => progress autorewrite with pull_orb in * : pull_orb.
+#[global] Hint Extern 1 => progress autorewrite with push_andb in * : push_andb.
+#[global] Hint Extern 1 => progress autorewrite with pull_andb in * : pull_andb.
+#[global] Hint Extern 1 => progress autorewrite with push_negb in * : push_negb.
+#[global] Hint Extern 1 => progress autorewrite with pull_negb in * : pull_negb.
+#[global] Hint Rewrite Bool.negb_orb Bool.negb_andb : push_negb.
+#[global] Hint Rewrite Bool.xorb_negb_negb : pull_negb.
+#[global] Hint Rewrite <- Bool.negb_orb Bool.negb_andb Bool.negb_xorb_l Bool.negb_xorb_r : pull_negb.
+#[global] Hint Rewrite Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : push_andb.
+#[global] Hint Rewrite <- Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : push_andb.
+#[global] Hint Rewrite Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : pull_andb.
+#[global] Hint Rewrite <- Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : pull_andb.
+#[global] Hint Rewrite Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : push_orb.
+#[global] Hint Rewrite <- Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : push_orb.
+#[global] Hint Rewrite <- Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : pull_orb.
+#[global] Hint Rewrite Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : pull_orb.
 
 Definition pull_bool_if_dep {A B} (f : forall b : bool, A b -> B b) (b : bool) (x : A true) (y : A false)
   : (if b return B b then f _ x else f _ y) = f b (if b return A b then x else y)
@@ -135,4 +135,4 @@ Lemma eqb_true_l x : Bool.eqb x true = x. Proof. now destruct x. Qed.
 Lemma eqb_true_r x : Bool.eqb true x = x. Proof. now destruct x. Qed.
 Lemma eqb_false_l x : Bool.eqb x false = negb x. Proof. now destruct x. Qed.
 Lemma eqb_false_r x : Bool.eqb false x = negb x. Proof. now destruct x. Qed.
-Hint Rewrite eqb_true_l eqb_true_r eqb_false_l eqb_false_r : boolsimplify.
+#[global] Hint Rewrite eqb_true_l eqb_true_r eqb_false_l eqb_false_r : boolsimplify.

--- a/src/Rewriter/Util/Bool/Reflect.v
+++ b/src/Rewriter/Util/Bool/Reflect.v
@@ -271,7 +271,7 @@ Ltac solve_reflect :=
   | false => repeat solve_reflect_step
   end.
 
-Hint Constructors reflect : typeclass_instances.
+#[global] Hint Constructors reflect : typeclass_instances.
 
 Local Hint Resolve -> Bool.eqb_true_iff : core.
 Local Hint Resolve <- Bool.eqb_true_iff : core.

--- a/src/Rewriter/Util/Decidable.v
+++ b/src/Rewriter/Util/Decidable.v
@@ -84,7 +84,7 @@ Global Instance dec_iff {A B} `{Decidable A, Decidable B} : Decidable (A <-> B) 
 Lemma dec_not {A} `{Decidable A} : Decidable (~A).
 Proof. solve_decidable_transparent. Defined.
 (** Disallow infinite loops of dec_not *)
-Hint Extern 0 (Decidable (~?A)) => apply (@dec_not A) : typeclass_instances.
+#[global] Hint Extern 0 (Decidable (~?A)) => apply (@dec_not A) : typeclass_instances.
 Global Instance dec_eq_unit : DecidableRel (@eq unit) | 10. exact _. Defined.
 Global Instance dec_eq_bool : DecidableRel (@eq bool) | 10. exact _. Defined.
 Global Instance dec_eq_Empty_set : DecidableRel (@eq Empty_set) | 10. exact _. Defined.
@@ -216,7 +216,7 @@ Ltac vm_decide := abstract vm_decide_no_check.
 Ltac lazy_decide := abstract lazy_decide_no_check.
 
 (** For dubious compatibility with [eauto using]. *)
-Hint Extern 2 (Decidable _) => progress unfold Decidable : typeclass_instances core.
+#[global] Hint Extern 2 (Decidable _) => progress unfold Decidable : typeclass_instances core.
 
 Definition cast_if_eq {T} `{DecidableRel (@eq T)} {P} (t t' : T) (v : P t) : option (P t')
   := match dec (t = t'), dec (t' = t') with

--- a/src/Rewriter/Util/FixCoqMistakes.v
+++ b/src/Rewriter/Util/FixCoqMistakes.v
@@ -89,4 +89,4 @@ Ltac solve_Proper_eq :=
       unify R R';
       apply (@reflexive_proper A R')
   end.
-Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.
+#[global] Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.

--- a/src/Rewriter/Util/LetIn.v
+++ b/src/Rewriter/Util/LetIn.v
@@ -32,7 +32,7 @@ Global Instance Proper_Let_In_nd_changevalue_forall {A B} {RB:relation B}
 Proof. cbv; intuition (subst; eauto). Qed.
 
 (* Strangely needed in some cases where we have [(fun _ => foo) ...] messing up dependency calculation *)
-Hint Extern 1 (Proper _ (@Let_In _ _)) => progress cbv beta : typeclass_instances.
+#[global] Hint Extern 1 (Proper _ (@Let_In _ _)) => progress cbv beta : typeclass_instances.
 
 Definition app_Let_In_nd {A B T} (f:B->T) (e:A) (C:A->B)
   : f (Let_In e C) = Let_In e (fun v => f (C v)) := eq_refl.
@@ -61,7 +61,7 @@ Ltac let_in_to_Let_In e :=
     with fun x => @?C x => C end (* match drops the type cast *)
   | ?x => x
   end.
-Hint Extern 0 (_call_let_in_to_Let_In ?e) => (
+#[global] Hint Extern 0 (_call_let_in_to_Let_In ?e) => (
   let e := let_in_to_Let_In e in eexact e
 ) : typeclass_instances.
 Ltac change_let_in_with_Let_In :=

--- a/src/Rewriter/Util/ListUtil.v
+++ b/src/Rewriter/Util/ListUtil.v
@@ -133,7 +133,7 @@ Create HintDb pull_update_nth discriminated.
 Create HintDb push_update_nth discriminated.
 Create HintDb znonzero discriminated.
 
-Hint Rewrite
+#[global] Hint Rewrite
   @app_length
   @rev_length
   @map_length
@@ -181,8 +181,8 @@ Module Export List.
     Lemma map_repeat x n : map f (List.repeat x n) = List.repeat (f x) n.
     Proof using Type. induction n; simpl List.repeat; simpl map; congruence. Qed.
   End Map.
-  Hint Rewrite @map_cons @map_nil @map_repeat : push_map.
-  Hint Rewrite @map_app : push_map.
+  #[global] Hint Rewrite @map_cons @map_nil @map_repeat : push_map.
+  #[global] Hint Rewrite @map_app : push_map.
 
   Section FlatMap.
     Lemma flat_map_nil {A B} (f:A->list B) : List.flat_map f (@nil A) = nil.
@@ -191,10 +191,10 @@ Module Export List.
       (List.flat_map f (x::xs) = (f x++List.flat_map f xs))%list.
     Proof. reflexivity. Qed.
   End FlatMap.
-  Hint Rewrite @flat_map_cons @flat_map_nil : push_flat_map.
+  #[global] Hint Rewrite @flat_map_cons @flat_map_nil : push_flat_map.
 
   Lemma rev_cons {A} x ls : @rev A (x :: ls) = rev ls ++ [x]. Proof. reflexivity. Qed.
-  Hint Rewrite @rev_cons : list.
+  #[global] Hint Rewrite @rev_cons : list.
 
   Section FoldRight.
     Context {A B} (f:B->A->A).
@@ -211,7 +211,7 @@ Module Export List.
       rewrite !fold_left_rev_right; reflexivity.
     Qed.
   End FoldRight.
-  Hint Rewrite @fold_right_nil @fold_right_cons @fold_right_snoc : simpl_fold_right push_fold_right.
+  #[global] Hint Rewrite @fold_right_nil @fold_right_cons @fold_right_snoc : simpl_fold_right push_fold_right.
 
   Section Partition.
     Lemma partition_nil {A} (f:A->_) : partition f nil = (nil, nil).
@@ -222,7 +222,7 @@ Module Export List.
                                              else ((fst (partition f xs)), x :: (snd (partition f xs))).
     Proof. cbv [partition]; break_match; reflexivity.           Qed.
   End Partition.
-  Hint Rewrite @partition_nil @partition_cons : push_partition.
+  #[global] Hint Rewrite @partition_nil @partition_cons : push_partition.
 
   Lemma in_seq len start n :
     In n (seq start len) <-> start <= n < start+len.
@@ -333,14 +333,14 @@ Module Export List.
     := combine (seq 0 (length ls)) ls.
 End List.
 
-Hint Rewrite @firstn_skipn : simpl_firstn.
-Hint Rewrite @firstn_skipn : simpl_skipn.
-Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : push_firstn.
-Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : simpl_firstn.
-Hint Rewrite @firstn_app : push_firstn.
-Hint Rewrite <- @firstn_cons @firstn_app @List.firstn_firstn : pull_firstn.
-Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : push_firstn.
-Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : simpl_firstn.
+#[global] Hint Rewrite @firstn_skipn : simpl_firstn.
+#[global] Hint Rewrite @firstn_skipn : simpl_skipn.
+#[global] Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : push_firstn.
+#[global] Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : simpl_firstn.
+#[global] Hint Rewrite @firstn_app : push_firstn.
+#[global] Hint Rewrite <- @firstn_cons @firstn_app @List.firstn_firstn : pull_firstn.
+#[global] Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : push_firstn.
+#[global] Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : simpl_firstn.
 
 Local Arguments value / _ _.
 Local Arguments error / _.
@@ -388,7 +388,7 @@ Definition set_nth {T} n x (xs:list T)
   := update_nth n (fun _ => x) xs.
 
 Definition splice_nth {T} n (x:T) xs := firstn n xs ++ x :: skipn (S n) xs.
-Hint Unfold splice_nth : core.
+#[global] Hint Unfold splice_nth : core.
 
 Fixpoint take_while {T} (f : T -> bool) (ls : list T) : list T
   := match ls with
@@ -591,26 +591,26 @@ Qed.
 Lemma nth_default_cons : forall {T} (x u0 : T) us, nth_default x (u0 :: us) 0 = u0.
 Proof. auto. Qed.
 
-Hint Rewrite @nth_default_cons : simpl_nth_default.
-Hint Rewrite @nth_default_cons : push_nth_default.
+#[global] Hint Rewrite @nth_default_cons : simpl_nth_default.
+#[global] Hint Rewrite @nth_default_cons : push_nth_default.
 
 Lemma nth_default_cons_S : forall {A} us (u0 : A) n d,
   nth_default d (u0 :: us) (S n) = nth_default d us n.
 Proof. boring. Qed.
 
-Hint Rewrite @nth_default_cons_S : simpl_nth_default.
-Hint Rewrite @nth_default_cons_S : push_nth_default.
+#[global] Hint Rewrite @nth_default_cons_S : simpl_nth_default.
+#[global] Hint Rewrite @nth_default_cons_S : push_nth_default.
 
 Lemma nth_default_nil : forall {T} n (d : T), nth_default d nil n = d.
 Proof. induction n; boring. Qed.
 
-Hint Rewrite @nth_default_nil : simpl_nth_default.
-Hint Rewrite @nth_default_nil : push_nth_default.
+#[global] Hint Rewrite @nth_default_nil : simpl_nth_default.
+#[global] Hint Rewrite @nth_default_nil : push_nth_default.
 
 Lemma nth_error_nil_error : forall {A} n, nth_error (@nil A) n = None.
 Proof. induction n; boring. Qed.
 
-Hint Rewrite @nth_error_nil_error : simpl_nth_error.
+#[global] Hint Rewrite @nth_error_nil_error : simpl_nth_error.
 
 Ltac nth_tac' :=
   intros; simpl in *; unfold error,value in *; repeat progress (match goal with
@@ -664,7 +664,7 @@ Proof.
   induction i as [|? IHi]; destruct xs; nth_tac'; rewrite IHi by lia; auto.
 Qed.
 Global Hint Resolve nth_error_length_error : core.
-Hint Rewrite @nth_error_length_error using lia : simpl_nth_error.
+#[global] Hint Rewrite @nth_error_length_error using lia : simpl_nth_error.
 
 Lemma map_nth_default : forall (A B : Type) (f : A -> B) n x y l,
   (n < length l) -> nth_default y (map f l) n = f (nth_default x l n).
@@ -679,7 +679,7 @@ Proof.
   lia.
 Qed.
 
-Hint Rewrite @map_nth_default using lia : push_nth_default.
+#[global] Hint Rewrite @map_nth_default using lia : push_nth_default.
 
 Ltac nth_tac :=
   repeat progress (try nth_tac'; try (match goal with
@@ -726,7 +726,7 @@ Lemma simpl_set_nth_S {T} x n
       end.
 Proof. intro; rewrite unfold_set_nth; reflexivity. Qed.
 
-Hint Rewrite @simpl_set_nth_S @simpl_set_nth_0 : simpl_set_nth.
+#[global] Hint Rewrite @simpl_set_nth_S @simpl_set_nth_0 : simpl_set_nth.
 
 Lemma update_nth_ext {T} f g n
   : forall xs, (forall x, nth_error xs n = Some x -> f x = g x)
@@ -753,19 +753,19 @@ Proof.
       try congruence; assumption.
 Qed.
 
-Hint Rewrite @update_nth_id_eq_specific using congruence : simpl_update_nth.
+#[global] Hint Rewrite @update_nth_id_eq_specific using congruence : simpl_update_nth.
 
 Lemma update_nth_id_eq : forall {T} f (H : forall x, f x = x) n (xs : list T),
     update_nth n f xs = xs.
 Proof. intros; apply update_nth_id_eq_specific; trivial. Qed.
 
-Hint Rewrite @update_nth_id_eq using congruence : simpl_update_nth.
+#[global] Hint Rewrite @update_nth_id_eq using congruence : simpl_update_nth.
 
 Lemma update_nth_id : forall {T} n (xs : list T),
     update_nth n (fun x => x) xs = xs.
 Proof. intros; apply update_nth_id_eq; trivial. Qed.
 
-Hint Rewrite @update_nth_id : simpl_update_nth.
+#[global] Hint Rewrite @update_nth_id : simpl_update_nth.
 
 Lemma nth_update_nth : forall m {T} (xs:list T) (n:nat) (f:T -> T),
   nth_error (update_nth m f xs) n =
@@ -780,15 +780,15 @@ Proof.
         edestruct eq_nat_dec; reflexivity. }
 Qed.
 
-Hint Rewrite @nth_update_nth : push_nth_error.
-Hint Rewrite <- @nth_update_nth : pull_nth_error.
+#[global] Hint Rewrite @nth_update_nth : push_nth_error.
+#[global] Hint Rewrite <- @nth_update_nth : pull_nth_error.
 
 Lemma length_update_nth : forall {T} i f (xs:list T), length (update_nth i f xs) = length xs.
 Proof.
   induction i, xs; boring.
 Qed.
 
-Hint Rewrite @length_update_nth : distr_length.
+#[global] Hint Rewrite @length_update_nth : distr_length.
 
 Lemma nth_set_nth : forall m {T} (xs:list T) (n:nat) x,
   nth_error (set_nth m x xs) n =
@@ -803,12 +803,12 @@ Proof.
           | exfalso; apply p; congruence ].
 Qed.
 
-Hint Rewrite @nth_set_nth : push_nth_error.
+#[global] Hint Rewrite @nth_set_nth : push_nth_error.
 
 Lemma length_set_nth : forall {T} i x (xs:list T), length (set_nth i x xs) = length xs.
 Proof. intros; apply length_update_nth. Qed.
 
-Hint Rewrite @length_set_nth : distr_length.
+#[global] Hint Rewrite @length_set_nth : distr_length.
 
 Lemma nth_error_length_exists_value : forall {A} (i : nat) (xs : list A),
   (i < length xs)%nat -> exists x, nth_error xs i = Some x.
@@ -829,7 +829,7 @@ Proof.
   unfold nth_default; boring.
 Qed.
 
-Hint Rewrite @nth_error_value_eq_nth_default using eassumption : simpl_nth_default.
+#[global] Hint Rewrite @nth_error_value_eq_nth_default using eassumption : simpl_nth_default.
 
 Lemma skipn0 : forall {T} (xs:list T), skipn 0 xs = xs.
 Proof. auto. Qed.
@@ -1015,7 +1015,7 @@ Proof.
   destruct (lt_dec n (length xs)); auto.
 Qed.
 
-Hint Rewrite @nth_default_app : push_nth_default.
+#[global] Hint Rewrite @nth_default_app : push_nth_default.
 
 Lemma combine_truncate_r : forall {A B} (xs : list A) (ys : list B),
   combine xs ys = combine xs (firstn (length xs) ys).
@@ -1045,25 +1045,25 @@ Lemma map_snd_combine {A B} (xs:list A) (ys:list B) : List.map snd (List.combine
 Proof.
   revert xs; induction ys; destruct xs; simpl; solve [ trivial | congruence ].
 Qed.
-Hint Rewrite @map_fst_combine @map_snd_combine : push_map.
+#[global] Hint Rewrite @map_fst_combine @map_snd_combine : push_map.
 
 Lemma skipn_nil : forall {A} n, skipn n nil = @nil A.
 Proof. destruct n; auto. Qed.
 
-Hint Rewrite @skipn_nil : simpl_skipn.
-Hint Rewrite @skipn_nil : push_skipn.
+#[global] Hint Rewrite @skipn_nil : simpl_skipn.
+#[global] Hint Rewrite @skipn_nil : push_skipn.
 
 Lemma skipn_0 : forall {A} xs, @skipn A 0 xs = xs.
 Proof. reflexivity. Qed.
 
-Hint Rewrite @skipn_0 : simpl_skipn.
-Hint Rewrite @skipn_0 : push_skipn.
+#[global] Hint Rewrite @skipn_0 : simpl_skipn.
+#[global] Hint Rewrite @skipn_0 : push_skipn.
 
 Lemma skipn_cons_S : forall {A} n x xs, @skipn A (S n) (x::xs) = @skipn A n xs.
 Proof. reflexivity. Qed.
 
-Hint Rewrite @skipn_cons_S : simpl_skipn.
-Hint Rewrite @skipn_cons_S : push_skipn.
+#[global] Hint Rewrite @skipn_cons_S : simpl_skipn.
+#[global] Hint Rewrite @skipn_cons_S : push_skipn.
 
 Lemma skipn_app : forall {A} n (xs ys : list A),
   skipn n (xs ++ ys) = skipn n xs ++ skipn (n - length xs) ys.
@@ -1071,7 +1071,7 @@ Proof.
   induction n, xs, ys; boring.
 Qed.
 
-Hint Rewrite @skipn_app : push_skipn.
+#[global] Hint Rewrite @skipn_app : push_skipn.
 
 Lemma skipn_skipn {A} n1 n2 (ls : list A)
   : skipn n2 (skipn n1 ls) = skipn (n1 + n2) ls.
@@ -1081,9 +1081,9 @@ Proof.
       boring.
 Qed.
 
-Hint Rewrite @skipn_skipn : simpl_skipn.
-Hint Rewrite <- @skipn_skipn : push_skipn.
-Hint Rewrite @skipn_skipn : pull_skipn.
+#[global] Hint Rewrite @skipn_skipn : simpl_skipn.
+#[global] Hint Rewrite <- @skipn_skipn : push_skipn.
+#[global] Hint Rewrite @skipn_skipn : pull_skipn.
 
 Lemma skipn_firstn {A} (ls : list A) n m
   : skipn n (firstn m ls) = firstn (m - n) (skipn n ls).
@@ -1098,8 +1098,8 @@ Qed.
 Lemma firstn_skipn_add' {A} (ls : list A) n m
   : firstn n (skipn m ls) = skipn m (firstn (n + m) ls).
 Proof. rewrite firstn_skipn_add; do 2 f_equal; auto with arith. Qed.
-Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_firstn.
-Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_skipn.
+#[global] Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_firstn.
+#[global] Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_skipn.
 
 Lemma firstn_app_inleft : forall {A} n (xs ys : list A), (n <= length xs)%nat ->
   firstn n (xs ++ ys) = firstn n xs.
@@ -1107,8 +1107,8 @@ Proof.
   induction n, xs, ys; boring; try lia.
 Qed.
 
-Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : simpl_firstn.
-Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : push_firstn.
+#[global] Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : simpl_firstn.
+#[global] Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : push_firstn.
 
 Lemma skipn_app_inleft : forall {A} n (xs ys : list A), (n <= length xs)%nat ->
   skipn n (xs ++ ys) = skipn n xs ++ ys.
@@ -1116,27 +1116,27 @@ Proof.
   induction n, xs, ys; boring; try lia.
 Qed.
 
-Hint Rewrite @skipn_app_inleft using solve [ distr_length ] : push_skipn.
+#[global] Hint Rewrite @skipn_app_inleft using solve [ distr_length ] : push_skipn.
 
 Lemma firstn_map : forall {A B} (f : A -> B) n (xs : list A), firstn n (map f xs) = map f (firstn n xs).
 Proof. induction n, xs; boring. Qed.
 
-Hint Rewrite @firstn_map : push_firstn.
-Hint Rewrite <- @firstn_map : pull_firstn.
+#[global] Hint Rewrite @firstn_map : push_firstn.
+#[global] Hint Rewrite <- @firstn_map : pull_firstn.
 
 Lemma skipn_map : forall {A B} (f : A -> B) n (xs : list A), skipn n (map f xs) = map f (skipn n xs).
 Proof. induction n, xs; boring. Qed.
 
-Hint Rewrite @skipn_map : push_skipn.
-Hint Rewrite <- @skipn_map : pull_skipn.
+#[global] Hint Rewrite @skipn_map : push_skipn.
+#[global] Hint Rewrite <- @skipn_map : pull_skipn.
 
 Lemma firstn_all : forall {A} n (xs:list A), n = length xs -> firstn n xs = xs.
 Proof.
   induction n, xs; boring; lia.
 Qed.
 
-Hint Rewrite @firstn_all using solve [ distr_length ] : simpl_firstn.
-Hint Rewrite @firstn_all using solve [ distr_length ] : push_firstn.
+#[global] Hint Rewrite @firstn_all using solve [ distr_length ] : simpl_firstn.
+#[global] Hint Rewrite @firstn_all using solve [ distr_length ] : push_firstn.
 
 Lemma skipn_all : forall {T} n (xs:list T),
   (n >= length xs)%nat ->
@@ -1145,8 +1145,8 @@ Proof.
   induction n, xs; boring; lia.
 Qed.
 
-Hint Rewrite @skipn_all using solve [ distr_length ] : simpl_skipn.
-Hint Rewrite @skipn_all using solve [ distr_length ] : push_skipn.
+#[global] Hint Rewrite @skipn_all using solve [ distr_length ] : simpl_skipn.
+#[global] Hint Rewrite @skipn_all using solve [ distr_length ] : push_skipn.
 
 Lemma firstn_app_sharp : forall {A} n (l l': list A),
   length l = n ->
@@ -1156,8 +1156,8 @@ Proof.
   rewrite firstn_app_inleft; auto using firstn_all; lia.
 Qed.
 
-Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : simpl_firstn.
-Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : push_firstn.
+#[global] Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : simpl_firstn.
+#[global] Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : push_firstn.
 
 Lemma skipn_app_sharp : forall {A} n (l l': list A),
   length l = n ->
@@ -1167,8 +1167,8 @@ Proof.
   rewrite skipn_app_inleft; try rewrite skipn_all; auto; lia.
 Qed.
 
-Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : simpl_skipn.
-Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : push_skipn.
+#[global] Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : simpl_skipn.
+#[global] Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : push_skipn.
 
 Lemma skipn_length : forall {A} n (xs : list A),
   length (skipn n xs) = (length xs - n)%nat.
@@ -1176,13 +1176,13 @@ Proof.
   induction n, xs; boring.
 Qed.
 
-Hint Rewrite @skipn_length : distr_length.
+#[global] Hint Rewrite @skipn_length : distr_length.
 
 Lemma length_cons : forall {T} (x:T) xs, length (x::xs) = S (length xs).
   reflexivity.
 Qed.
 
-Hint Rewrite @length_cons : distr_length.
+#[global] Hint Rewrite @length_cons : distr_length.
 
 Lemma length_cons_full {T} n (x:list T) (t:T) (H: length (t :: x) = S n)
   : length x = n.
@@ -1200,17 +1200,17 @@ Qed.
 
 Lemma length_tl {A} ls : length (@tl A ls) = (length ls - 1)%nat.
 Proof. destruct ls; cbn [tl length]; lia. Qed.
-Hint Rewrite @length_tl : distr_length.
+#[global] Hint Rewrite @length_tl : distr_length.
 
 Lemma length_snoc {A : Type} (l : list A) a : length (l ++ [a]) = S (length l).
 Proof. simpl_list; boring. Qed.
 
-Hint Rewrite @length_snoc : distr_length.
+#[global] Hint Rewrite @length_snoc : distr_length.
 
 Lemma combine_cons : forall {A B} a b (xs:list A) (ys:list B),
   combine (a :: xs) (b :: ys) = (a,b) :: combine xs ys.
 Proof. reflexivity. Qed.
-Hint Rewrite @combine_cons : push_combine.
+#[global] Hint Rewrite @combine_cons : push_combine.
 
 Lemma firstn_combine : forall {A B} n (xs:list A) (ys:list B),
   firstn n (combine xs ys) = combine (firstn n xs) (firstn n ys).
@@ -1218,15 +1218,15 @@ Proof.
   induction n, xs, ys; boring.
 Qed.
 
-Hint Rewrite @firstn_combine : push_firstn.
-Hint Rewrite <- @firstn_combine : pull_firstn.
+#[global] Hint Rewrite @firstn_combine : push_firstn.
+#[global] Hint Rewrite <- @firstn_combine : pull_firstn.
 
 Lemma combine_nil_r : forall {A B} (xs:list A),
   combine xs (@nil B) = nil.
 Proof.
   induction xs; boring.
 Qed.
-Hint Rewrite @combine_nil_r : push_combine.
+#[global] Hint Rewrite @combine_nil_r : push_combine.
 
 Lemma combine_snoc {A B} xs : forall ys x y,
     length xs = length ys ->
@@ -1235,7 +1235,7 @@ Proof.
   induction xs; intros; destruct ys; distr_length; cbn;
     try rewrite IHxs by lia; reflexivity.
 Qed.
-Hint Rewrite @combine_snoc using (solve [distr_length]) : push_combine.
+#[global] Hint Rewrite @combine_snoc using (solve [distr_length]) : push_combine.
 
 Lemma skipn_combine : forall {A B} n (xs:list A) (ys:list B),
   skipn n (combine xs ys) = combine (skipn n xs) (skipn n ys).
@@ -1244,8 +1244,8 @@ Proof.
   rewrite combine_nil_r; reflexivity.
 Qed.
 
-Hint Rewrite @skipn_combine : push_skipn.
-Hint Rewrite <- @skipn_combine : pull_skipn.
+#[global] Hint Rewrite @skipn_combine : push_skipn.
+#[global] Hint Rewrite <- @skipn_combine : pull_skipn.
 
 Lemma break_list_last: forall {T} (xs:list T),
   xs = nil \/ exists xs' y, xs = xs' ++ y :: nil.
@@ -1280,7 +1280,7 @@ Proof.
   auto.
 Qed.
 
-Hint Rewrite @nil_length0 : distr_length.
+#[global] Hint Rewrite @nil_length0 : distr_length.
 
 Lemma nth_error_Some_nth_default : forall {T} i x (l : list T), (i < length l)%nat ->
   nth_error l i = Some (nth_default x l i).
@@ -1295,12 +1295,12 @@ Qed.
 Lemma update_nth_cons : forall {T} f (u0 : T) us, update_nth 0 f (u0 :: us) = (f u0) :: us.
 Proof. reflexivity. Qed.
 
-Hint Rewrite @update_nth_cons : simpl_update_nth.
+#[global] Hint Rewrite @update_nth_cons : simpl_update_nth.
 
 Lemma set_nth_cons : forall {T} (x u0 : T) us, set_nth 0 x (u0 :: us) = x :: us.
 Proof. intros; apply update_nth_cons. Qed.
 
-Hint Rewrite @set_nth_cons : simpl_set_nth.
+#[global] Hint Rewrite @set_nth_cons : simpl_set_nth.
 
 Lemma cons_update_nth : forall {T} n f (y : T) us,
   y :: update_nth n f us = update_nth (S n) f (y :: us).
@@ -1308,25 +1308,25 @@ Proof.
   induction n; boring.
 Qed.
 
-Hint Rewrite <- @cons_update_nth : simpl_update_nth.
+#[global] Hint Rewrite <- @cons_update_nth : simpl_update_nth.
 
 Lemma update_nth_nil : forall {T} n f, update_nth n f (@nil T) = @nil T.
 Proof.
   induction n; boring.
 Qed.
 
-Hint Rewrite @update_nth_nil : simpl_update_nth.
+#[global] Hint Rewrite @update_nth_nil : simpl_update_nth.
 
 Lemma cons_set_nth : forall {T} n (x y : T) us,
   y :: set_nth n x us = set_nth (S n) x (y :: us).
 Proof. intros; apply cons_update_nth. Qed.
 
-Hint Rewrite <- @cons_set_nth : simpl_set_nth.
+#[global] Hint Rewrite <- @cons_set_nth : simpl_set_nth.
 
 Lemma set_nth_nil : forall {T} n (x : T), set_nth n x nil = nil.
 Proof. intros; apply update_nth_nil. Qed.
 
-Hint Rewrite @set_nth_nil : simpl_set_nth.
+#[global] Hint Rewrite @set_nth_nil : simpl_set_nth.
 
 Lemma skipn_nth_default : forall {T} n us (d : T), (n < length us)%nat ->
  skipn n us = nth_default d us n :: skipn (S n) us.
@@ -1349,7 +1349,7 @@ Proof.
   congruence.
 Qed.
 
-Hint Rewrite @nth_default_out_of_bounds using lia : simpl_nth_default.
+#[global] Hint Rewrite @nth_default_out_of_bounds using lia : simpl_nth_default.
 
 Ltac nth_error_inbounds :=
   match goal with
@@ -1442,7 +1442,7 @@ Proof.
   nth_tac.
 Qed.
 
-Hint Rewrite @map_nth_default_always : push_nth_default.
+#[global] Hint Rewrite @map_nth_default_always : push_nth_default.
 
 Lemma map_S_seq {A} (f:nat->A) len : forall start,
   List.map (fun i => f (S i)) (seq start len) = List.map f (seq (S start) len).
@@ -1543,7 +1543,7 @@ Proof.
   assert (n = m) by lia; subst; reflexivity.
 Qed.
 
-Hint Rewrite @firstn_firstn using lia : push_firstn.
+#[global] Hint Rewrite @firstn_firstn using lia : push_firstn.
 
 Lemma firstn_succ : forall {A} (d : A) n l, (n < length l)%nat ->
   firstn (S n) l = (firstn n l) ++ nth_default d l n :: nil.
@@ -1562,7 +1562,7 @@ Proof.
   revert k a; induction b as [|? IHb], k; simpl; try reflexivity.
   intros; rewrite IHb; reflexivity.
 Qed.
-Hint Rewrite @firstn_seq : push_firstn.
+#[global] Hint Rewrite @firstn_seq : push_firstn.
 
 Lemma skipn_seq k a b
   : skipn k (seq a b) = seq (k + a) (b - k).
@@ -1577,7 +1577,7 @@ Proof.
   rewrite IHn by lia; reflexivity.
 Qed.
 
-Hint Rewrite @update_nth_out_of_bounds using lia : simpl_update_nth.
+#[global] Hint Rewrite @update_nth_out_of_bounds using lia : simpl_update_nth.
 
 
 Lemma update_nth_nth_default_full : forall {A} (d:A) n f l i,
@@ -1596,14 +1596,14 @@ Proof.
                    | lia ].
 Qed.
 
-Hint Rewrite @update_nth_nth_default_full : push_nth_default.
+#[global] Hint Rewrite @update_nth_nth_default_full : push_nth_default.
 
 Lemma update_nth_nth_default : forall {A} (d:A) n f l i, (0 <= i < length l)%nat ->
   nth_default d (update_nth n f l) i =
   if (eq_nat_dec i n) then f (nth_default d l i) else nth_default d l i.
 Proof. intros; rewrite update_nth_nth_default_full; repeat break_match; boring. Qed.
 
-Hint Rewrite @update_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
+#[global] Hint Rewrite @update_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
 
 Lemma set_nth_nth_default_full : forall {A} (d:A) n v l i,
   nth_default d (set_nth n v l) i =
@@ -1613,14 +1613,14 @@ Lemma set_nth_nth_default_full : forall {A} (d:A) n v l i,
   else d.
 Proof. intros; apply update_nth_nth_default_full; assumption. Qed.
 
-Hint Rewrite @set_nth_nth_default_full : push_nth_default.
+#[global] Hint Rewrite @set_nth_nth_default_full : push_nth_default.
 
 Lemma set_nth_nth_default : forall {A} (d:A) n x l i, (0 <= i < length l)%nat ->
   nth_default d (set_nth n x l) i =
   if (eq_nat_dec i n) then x else nth_default d l i.
 Proof. intros; apply update_nth_nth_default; assumption. Qed.
 
-Hint Rewrite @set_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
+#[global] Hint Rewrite @set_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
 
 Lemma nth_default_preserves_properties : forall {A} (P : A -> Prop) l n d,
   (forall x, In x l -> P x) -> P d -> P (nth_default d l n).
@@ -1675,7 +1675,7 @@ Proof.
   autorewrite with push_firstn; reflexivity.
 Qed.
 
-Hint Rewrite @sum_firstn_all_succ using lia : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_all_succ using lia : simpl_sum_firstn.
 
 Lemma sum_firstn_all : forall n l, (length l <= n)%nat ->
   sum_firstn l n = sum_firstn l (length l).
@@ -1684,7 +1684,7 @@ Proof.
   autorewrite with push_firstn; reflexivity.
 Qed.
 
-Hint Rewrite @sum_firstn_all using lia : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_all using lia : simpl_sum_firstn.
 
 Lemma sum_firstn_succ_default : forall l i,
   sum_firstn l (S i) = (nth_default 0 l i + sum_firstn l i)%Z.
@@ -1695,7 +1695,7 @@ Proof.
   rewrite IHl; lia.
 Qed.
 
-Hint Rewrite @sum_firstn_succ_default : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_succ_default : simpl_sum_firstn.
 
 Lemma sum_firstn_0 : forall xs,
   sum_firstn xs 0 = 0%Z.
@@ -1703,7 +1703,7 @@ Proof.
   destruct xs; reflexivity.
 Qed.
 
-Hint Rewrite @sum_firstn_0 : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_0 : simpl_sum_firstn.
 
 Lemma sum_firstn_succ : forall l i x,
   nth_error l i = Some x ->
@@ -1713,7 +1713,7 @@ Proof.
   erewrite nth_error_value_eq_nth_default by eassumption; reflexivity.
 Qed.
 
-Hint Rewrite @sum_firstn_succ using congruence : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_succ using congruence : simpl_sum_firstn.
 
 Lemma sum_firstn_succ_cons : forall x xs i,
   sum_firstn (x :: xs) (S i) = (x + sum_firstn xs i)%Z.
@@ -1721,13 +1721,13 @@ Proof.
   unfold sum_firstn; simpl; reflexivity.
 Qed.
 
-Hint Rewrite @sum_firstn_succ_cons : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_succ_cons : simpl_sum_firstn.
 
 Lemma sum_firstn_nil : forall i,
   sum_firstn nil i = 0%Z.
 Proof. destruct i; reflexivity. Qed.
 
-Hint Rewrite @sum_firstn_nil : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_nil : simpl_sum_firstn.
 
 Lemma sum_firstn_succ_default_rev : forall l i,
   sum_firstn l i = (sum_firstn l (S i) - nth_default 0 l i)%Z.
@@ -1769,23 +1769,23 @@ Proof.
   intros; rewrite sum_firstn_app; autorewrite with simpl_sum_firstn.
   do 2 f_equal; lia.
 Qed.
-Hint Rewrite @sum_firstn_app_sum : simpl_sum_firstn.
+#[global] Hint Rewrite @sum_firstn_app_sum : simpl_sum_firstn.
 
 Lemma sum_cons xs x : sum (x :: xs) = (x + sum xs)%Z.
 Proof. reflexivity. Qed.
-Hint Rewrite sum_cons : push_sum.
+#[global] Hint Rewrite sum_cons : push_sum.
 
 Lemma sum_nil : sum nil = 0%Z.
 Proof. reflexivity. Qed.
-Hint Rewrite sum_nil : push_sum.
+#[global] Hint Rewrite sum_nil : push_sum.
 
 Lemma sum_app x y : sum (x ++ y) = (sum x + sum y)%Z.
 Proof. induction x; rewrite ?app_nil_l, <-?app_comm_cons; autorewrite with push_sum; lia. Qed.
-Hint Rewrite sum_app : push_sum.
+#[global] Hint Rewrite sum_app : push_sum.
 
 Lemma sum_rev x : sum (rev x) = sum x.
 Proof. induction x; cbn [rev]; autorewrite with push_sum; lia. Qed.
-Hint Rewrite sum_rev : push_sum.
+#[global] Hint Rewrite sum_rev : push_sum.
 
 Lemma nth_error_skipn : forall {A} n (l : list A) m,
 nth_error (skipn n l) m = nth_error l (n + m).
@@ -1793,7 +1793,7 @@ Proof.
 induction n as [|n IHn]; destruct l; boring.
 apply nth_error_nil_error.
 Qed.
-Hint Rewrite @nth_error_skipn : push_nth_error.
+#[global] Hint Rewrite @nth_error_skipn : push_nth_error.
 
 Lemma nth_default_skipn : forall {A} (l : list A) d n m, nth_default d (skipn n l) m = nth_default d l (n + m).
 Proof.
@@ -1801,7 +1801,7 @@ cbv [nth_default]; intros.
 rewrite nth_error_skipn.
 reflexivity.
 Qed.
-Hint Rewrite @nth_default_skipn : push_nth_default.
+#[global] Hint Rewrite @nth_default_skipn : push_nth_default.
 
 Lemma sum_firstn_skipn : forall l n m, sum_firstn l (n + m) = (sum_firstn l n + sum_firstn (skipn n l) m)%Z.
 Proof.
@@ -1819,7 +1819,7 @@ Proof.
   rewrite nth_error_seq.
   break_innermost_match; solve [ trivial | lia ].
 Qed.
-Hint Rewrite @nth_default_seq_inbounds using lia : push_nth_default.
+#[global] Hint Rewrite @nth_default_seq_inbounds using lia : push_nth_default.
 
 Lemma sum_firstn_prefix_le' : forall l n m, (forall x, In x l -> (0 <= x)%Z) ->
                                             (sum_firstn l n <= sum_firstn l (n + m))%Z.
@@ -1883,7 +1883,7 @@ Lemma sum_firstn_app_hint : forall xs ys n, NotSum xs n ->
   sum_firstn (xs ++ ys) n = (sum_firstn xs n + sum_firstn ys (n - length xs))%Z.
 Proof. auto using sum_firstn_app. Qed.
 
-Hint Rewrite sum_firstn_app_hint using solve [ NotSum ] : simpl_sum_firstn.
+#[global] Hint Rewrite sum_firstn_app_hint using solve [ NotSum ] : simpl_sum_firstn.
 
 
 Lemma nth_default_map2 : forall {A B C} (f : A -> B -> C) ls1 ls2 i d d1 d2,
@@ -1950,7 +1950,7 @@ Section OpaqueMap2.
     rewrite map2_cons, !length_cons, IHls1.
     auto.
   Qed.
-  Hint Rewrite @map2_length : distr_length.
+  #[local] Hint Rewrite @map2_length : distr_length.
 
 
   Lemma map2_app : forall A B C (f : A -> B -> C) ls1 ls2 ls1' ls2',
@@ -1963,7 +1963,7 @@ Section OpaqueMap2.
     rewrite IHls1; auto.
   Qed.
 End OpaqueMap2.
-Hint Rewrite @map2_length : distr_length.
+#[global] Hint Rewrite @map2_length : distr_length.
 
 Lemma firstn_update_nth {A}
   : forall f m n (xs : list A), firstn m (update_nth n f xs) = update_nth n f (firstn m xs).
@@ -1973,10 +1973,10 @@ Proof.
     congruence.
 Qed.
 
-Hint Rewrite @firstn_update_nth : push_firstn.
-Hint Rewrite @firstn_update_nth : pull_update_nth.
-Hint Rewrite <- @firstn_update_nth : pull_firstn.
-Hint Rewrite <- @firstn_update_nth : push_update_nth.
+#[global] Hint Rewrite @firstn_update_nth : push_firstn.
+#[global] Hint Rewrite @firstn_update_nth : pull_update_nth.
+#[global] Hint Rewrite <- @firstn_update_nth : pull_firstn.
+#[global] Hint Rewrite <- @firstn_update_nth : push_update_nth.
 
 Require Import Coq.Lists.SetoidList.
 Global Instance Proper_nth_default : forall A eq,
@@ -2041,14 +2041,14 @@ Proof.
   + rewrite firstn_all2 by lia.
     auto.
 Qed.
-Hint Rewrite @nth_default_firstn : push_nth_default.
+#[global] Hint Rewrite @nth_default_firstn : push_nth_default.
 
 Lemma nth_error_repeat {T} x n i v : nth_error (@repeat T x n) i = Some v -> v = x.
 Proof.
   revert n x v; induction i as [|i IHi]; destruct n; simpl in *; eauto; congruence.
 Qed.
 
-Hint Rewrite repeat_length : distr_length.
+#[global] Hint Rewrite repeat_length : distr_length.
 
 Lemma repeat_spec_iff : forall {A} (ls : list A) x n,
     (length ls = n /\ forall y, In y ls -> y = x) <-> ls = repeat x n.
@@ -2072,12 +2072,12 @@ Proof. destruct n; reflexivity. Qed.
 Lemma firstn_repeat : forall {A} x n k, firstn k (@repeat A x n) = repeat x (min k n).
 Proof. induction n, k; boring. Qed.
 
-Hint Rewrite @firstn_repeat : push_firstn.
+#[global] Hint Rewrite @firstn_repeat : push_firstn.
 
 Lemma skipn_repeat : forall {A} x n k, skipn k (@repeat A x n) = repeat x (n - k).
 Proof. induction n, k; boring. Qed.
 
-Hint Rewrite @skipn_repeat : push_skipn.
+#[global] Hint Rewrite @skipn_repeat : push_skipn.
 
 Global Instance Proper_map {A B} {RA RB} {Equivalence_RB:Equivalence RB}
   : Proper ((RA==>RB) ==> eqlistA RA ==> eqlistA RB) (@List.map A B).
@@ -2261,7 +2261,7 @@ Proof. induction ls as [|x xs IHxs]; cbn; [ | rewrite IHxs ]; reflexivity. Qed.
 Lemma flat_map_app A B (f : A -> list B) xs ys
   : flat_map f (xs ++ ys) = flat_map f xs ++ flat_map f ys.
 Proof. induction xs as [|x xs IHxs]; cbn; rewrite ?IHxs, <- ?app_assoc; reflexivity. Qed.
-Hint Rewrite flat_map_app : push_flat_map.
+#[global] Hint Rewrite flat_map_app : push_flat_map.
 Lemma map_flat_map A B C (f : A -> list B) (g : B -> C) xs
   : map g (flat_map f xs) = flat_map (fun x => map g (f x)) xs.
 Proof. induction xs as [|x xs IHxs]; cbn; rewrite ?map_app; congruence. Qed.
@@ -2320,7 +2320,7 @@ Lemma nth_default_repeat A (v:A) n (d:A) i : nth_default d (repeat v n) i = if d
 Proof.
   cbv [nth_default]; rewrite nth_error_repeat_alt; now break_innermost_match.
 Qed.
-Hint Rewrite nth_default_repeat : push_nth_default simpl_nth_default.
+#[global] Hint Rewrite nth_default_repeat : push_nth_default simpl_nth_default.
 Lemma fold_right_if_dec_eq_seq A start len i f (x v : A)
   : ((start <= i < start + len)%nat -> f i v = x)
     -> (forall j v, (i <> j)%nat -> f j v = v)

--- a/src/Rewriter/Util/NatUtil.v
+++ b/src/Rewriter/Util/NatUtil.v
@@ -51,9 +51,9 @@ Global Strategy expand [nat_rect_arrow_nodep nat_rect_nodep Thunked.nat_rect].
 Create HintDb natsimplify discriminated.
 
 Global Hint Resolve mod_bound_pos plus_le_compat : arith.
-Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using lia : natsimplify.
+#[global] Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using lia : natsimplify.
 
-Hint Rewrite sub_diag add_0_l add_0_r sub_0_r sub_succ : natsimplify.
+#[global] Hint Rewrite sub_diag add_0_l add_0_r sub_0_r sub_succ : natsimplify.
 
 Local Open Scope nat_scope.
 
@@ -282,18 +282,18 @@ Proof.
   destruct a; simpl; lia.
 Qed.
 
-Hint Rewrite S_pred_nonzero using lia : natsimplify.
+#[global] Hint Rewrite S_pred_nonzero using lia : natsimplify.
 
 Lemma mod_same_eq a b : a <> 0 -> a = b -> b mod a = 0.
 Proof. intros; subst; apply mod_same; assumption. Qed.
 
-Hint Rewrite @mod_same_eq using lia : natsimplify.
+#[global] Hint Rewrite @mod_same_eq using lia : natsimplify.
 Global Hint Resolve mod_same_eq : arith.
 
 Lemma mod_mod_eq a b c : a <> 0 -> b = c mod a -> b mod a = b.
 Proof. intros; subst; autorewrite with natsimplify; reflexivity. Qed.
 
-Hint Rewrite @mod_mod_eq using (reflexivity || lia) : natsimplify.
+#[global] Hint Rewrite @mod_mod_eq using (reflexivity || lia) : natsimplify.
 
 Local Arguments minus !_ !_.
 
@@ -309,7 +309,7 @@ Proof.
       try congruence; try reflexivity.
 Qed.
 
-Hint Rewrite S_mod_full using lia : natsimplify.
+#[global] Hint Rewrite S_mod_full using lia : natsimplify.
 
 Lemma S_mod a b : a <> 0 -> S (b mod a) <> a -> (S b) mod a = S (b mod a).
 Proof.
@@ -317,7 +317,7 @@ Proof.
   edestruct eq_nat_dec; lia.
 Qed.
 
-Hint Rewrite S_mod using (lia || autorewrite with natsimplify; lia) : natsimplify.
+#[global] Hint Rewrite S_mod using (lia || autorewrite with natsimplify; lia) : natsimplify.
 
 Lemma eq_nat_dec_refl x : eq_nat_dec x x = left (Logic.eq_refl x).
 Proof.
@@ -325,7 +325,7 @@ Proof.
   apply f_equal, Eqdep_dec.UIP_dec, eq_nat_dec.
 Qed.
 
-Hint Rewrite eq_nat_dec_refl : natsimplify.
+#[global] Hint Rewrite eq_nat_dec_refl : natsimplify.
 
 (** Helper to get around the lack of function extensionality *)
 Definition eq_nat_dec_right_val n m (pf0 : n <> m) : { pf | eq_nat_dec n m = right pf }.
@@ -346,16 +346,16 @@ Proof.
   edestruct eq_nat_dec_right_val; assumption.
 Qed.
 
-Hint Rewrite eq_nat_dec_S_n : natsimplify.
+#[global] Hint Rewrite eq_nat_dec_S_n : natsimplify.
 
 Lemma eq_nat_dec_n_S n : eq_nat_dec n (S n) = right (proj1_sig (@eq_nat_dec_right_val _ _ (n_Sn n))).
 Proof.
   edestruct eq_nat_dec_right_val; assumption.
 Qed.
 
-Hint Rewrite eq_nat_dec_n_S : natsimplify.
+#[global] Hint Rewrite eq_nat_dec_n_S : natsimplify.
 
-Hint Rewrite Max.max_0_l Max.max_0_r Max.max_idempotent Min.min_0_l Min.min_0_r Min.min_idempotent : natsimplify.
+#[global] Hint Rewrite Max.max_0_l Max.max_0_r Max.max_idempotent Min.min_0_l Min.min_0_r Min.min_idempotent : natsimplify.
 
 (** Helper to get around the lack of function extensionality *)
 Definition le_dec_right_val n m (pf0 : ~n <= m) : { pf | le_dec n m = right pf }.
@@ -370,28 +370,28 @@ Definition lt_dec_right_val n m (pf0 : ~n < m) : { pf | lt_dec n m = right pf }
 
 Lemma lt_dec_irrefl n : lt_dec n n = right (proj1_sig (@lt_dec_right_val _ _ (lt_irrefl n))).
 Proof. edestruct lt_dec_right_val; assumption. Qed.
-Hint Rewrite lt_dec_irrefl : natsimplify.
+#[global] Hint Rewrite lt_dec_irrefl : natsimplify.
 
 Lemma not_lt_n_pred_n n : ~n < pred n.
 Proof. destruct n; simpl; lia. Qed.
 
 Lemma lt_dec_n_pred_n n : lt_dec n (pred n) = right (proj1_sig (@lt_dec_right_val _ _ (not_lt_n_pred_n n))).
 Proof. edestruct lt_dec_right_val; assumption. Qed.
-Hint Rewrite lt_dec_n_pred_n : natsimplify.
+#[global] Hint Rewrite lt_dec_n_pred_n : natsimplify.
 
 Lemma le_dec_refl n : le_dec n n = left (le_refl n).
 Proof.
   edestruct le_dec; try ((idtac + exfalso); lia).
   apply f_equal, le_unique.
 Qed.
-Hint Rewrite le_dec_refl : natsimplify.
+#[global] Hint Rewrite le_dec_refl : natsimplify.
 
 Lemma le_dec_pred_l n : le_dec (pred n) n = left (le_pred_l n).
 Proof.
   edestruct le_dec; [ | destruct n; simpl in *; (idtac + exfalso); lia ].
   apply f_equal, le_unique.
 Qed.
-Hint Rewrite le_dec_pred_l : natsimplify.
+#[global] Hint Rewrite le_dec_pred_l : natsimplify.
 
 Lemma le_pred_plus_same n : n <= pred (n + n).
 Proof. destruct n; simpl; lia. Qed.
@@ -401,19 +401,19 @@ Proof.
   edestruct le_dec; [ | destruct n; simpl in *; (idtac + exfalso); lia ].
   apply f_equal, le_unique.
 Qed.
-Hint Rewrite le_dec_pred_plus_same : natsimplify.
+#[global] Hint Rewrite le_dec_pred_plus_same : natsimplify.
 
 Lemma minus_S_diag x : (S x - x = 1)%nat.
 Proof. lia. Qed.
-Hint Rewrite minus_S_diag : natsimplify.
+#[global] Hint Rewrite minus_S_diag : natsimplify.
 
 Lemma min_idempotent_S_l x : min (S x) x = x.
 Proof. lia *. Qed.
-Hint Rewrite min_idempotent_S_l : natsimplify.
+#[global] Hint Rewrite min_idempotent_S_l : natsimplify.
 
 Lemma min_idempotent_S_r x : min x (S x) = x.
 Proof. lia *. Qed.
-Hint Rewrite min_idempotent_S_r : natsimplify.
+#[global] Hint Rewrite min_idempotent_S_r : natsimplify.
 
 Lemma mod_pow_same b e : b <> 0 -> e <> 0 -> b^e mod b = 0.
 Proof.
@@ -493,35 +493,35 @@ Qed.
 
 Lemma min_x_xy x y : Nat.min x (Nat.min x y) = Nat.min x y.
 Proof. now rewrite Nat.min_assoc; autorewrite with natsimplify. Qed.
-Hint Rewrite min_x_xy : natsimplify.
+#[global] Hint Rewrite min_x_xy : natsimplify.
 
 Lemma min_x_yx x y : Nat.min x (Nat.min y x) = Nat.min x y.
 Proof. now rewrite Nat.min_comm, <- Nat.min_assoc, Nat.min_comm; autorewrite with natsimplify. Qed.
-Hint Rewrite min_x_yx : natsimplify.
+#[global] Hint Rewrite min_x_yx : natsimplify.
 
 Lemma min_xy_x x y : Nat.min (Nat.min x y) x = Nat.min x y.
 Proof. now rewrite Nat.min_comm, Nat.min_assoc; autorewrite with natsimplify. Qed.
-Hint Rewrite min_xy_x : natsimplify.
+#[global] Hint Rewrite min_xy_x : natsimplify.
 
 Lemma min_yx_x x y : Nat.min (Nat.min y x) x = Nat.min y x.
 Proof. now rewrite <- Nat.min_assoc; autorewrite with natsimplify. Qed.
-Hint Rewrite min_yx_x : natsimplify.
+#[global] Hint Rewrite min_yx_x : natsimplify.
 
 Lemma max_x_xy x y : Nat.max x (Nat.max x y) = Nat.max x y.
 Proof. now rewrite Nat.max_assoc; autorewrite with natsimplify. Qed.
-Hint Rewrite max_x_xy : natsimplify.
+#[global] Hint Rewrite max_x_xy : natsimplify.
 
 Lemma max_x_yx x y : Nat.max x (Nat.max y x) = Nat.max x y.
 Proof. now rewrite Nat.max_comm, <- Nat.max_assoc, Nat.max_comm; autorewrite with natsimplify. Qed.
-Hint Rewrite max_x_yx : natsimplify.
+#[global] Hint Rewrite max_x_yx : natsimplify.
 
 Lemma max_xy_x x y : Nat.max (Nat.max x y) x = Nat.max x y.
 Proof. now rewrite Nat.max_comm, Nat.max_assoc; autorewrite with natsimplify. Qed.
-Hint Rewrite max_xy_x : natsimplify.
+#[global] Hint Rewrite max_xy_x : natsimplify.
 
 Lemma max_yx_x x y : Nat.max (Nat.max y x) x = Nat.max y x.
 Proof. now rewrite <- Nat.max_assoc; autorewrite with natsimplify. Qed.
-Hint Rewrite max_yx_x : natsimplify.
+#[global] Hint Rewrite max_yx_x : natsimplify.
 
 Ltac inversion_nat_eq_step :=
   match goal with

--- a/src/Rewriter/Util/Option.v
+++ b/src/Rewriter/Util/Option.v
@@ -198,7 +198,7 @@ Global Instance Proper_option_rect_nd_changebody
 Proof. cbv; repeat (intro || break_match); intuition. Qed.
 
 (* FIXME: there used to be a typeclass resolution hint here, something like
-  Hint Extern 1 (Proper _ (@option_rect ?A (fun _ => ?B))) => exact (@Proper_option_rect_nd_changebody A B _ _) : typeclass_instances.
+  #[global] Hint Extern 1 (Proper _ (@option_rect ?A (fun _ => ?B))) => exact (@Proper_option_rect_nd_changebody A B _ _) : typeclass_instances.
  but I could not get it working after generalizing [RB] from [Logic.eq] ~ andreser *)
 
 Global Instance Proper_option_rect_nd_changevalue

--- a/src/Rewriter/Util/PrimitiveProd.v
+++ b/src/Rewriter/Util/PrimitiveProd.v
@@ -74,7 +74,7 @@ Local Arguments f_equal {_ _} _ {_ _} _.
 
 Definition fst_pair {A B} (a:A) (b:B) : fst (a,b) = a := eq_refl.
 Definition snd_pair {A B} (a:A) (b:B) : snd (a,b) = b := eq_refl.
-Create HintDb cancel_primpair discriminated. Hint Rewrite @fst_pair @snd_pair : cancel_primpair.
+Create HintDb cancel_primpair discriminated. #[global] Hint Rewrite @fst_pair @snd_pair : cancel_primpair.
 
 (** ** Equality for [prod] *)
 Section prod.
@@ -151,9 +151,9 @@ Global Instance iffTp_iffTp_prod_Proper
 Proof.
   intros ?? [?] ?? [?]; constructor; tauto.
 Defined.
-Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
+#[global] Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
+#[global] Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
+#[global] Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
 
 (** ** Useful Tactics *)
 (** *** [inversion_prod] *)

--- a/src/Rewriter/Util/PrimitiveSigma.v
+++ b/src/Rewriter/Util/PrimitiveSigma.v
@@ -97,7 +97,7 @@ Local Arguments f_equal {_ _} _ {_ _} _.
 
 Definition projT1_existT {A B} (a:A) (b:B a) : projT1 (existT B a b) = a := eq_refl.
 Definition projT2_existT {A B} (a:A) (b:B a) : projT2 (existT B a b) = b := eq_refl.
-Create HintDb cancel_primsig discriminated. Hint Rewrite @projT1_existT @projT2_existT : cancel_primsig.
+Create HintDb cancel_primsig discriminated. #[global] Hint Rewrite @projT1_existT @projT2_existT : cancel_primsig.
 
 (** ** Equality for [sigT] *)
 Section sigT.

--- a/src/Rewriter/Util/Prod.v
+++ b/src/Rewriter/Util/Prod.v
@@ -82,7 +82,7 @@ Global Strategy expand [prod_rect_nodep].
 
 Definition fst_pair {A B} (a:A) (b:B) : fst (a,b) = a := eq_refl.
 Definition snd_pair {A B} (a:A) (b:B) : snd (a,b) = b := eq_refl.
-Create HintDb cancel_pair discriminated. Hint Rewrite @fst_pair @snd_pair : cancel_pair.
+Create HintDb cancel_pair discriminated. #[global] Hint Rewrite @fst_pair @snd_pair : cancel_pair.
 
 (** ** Equality for [prod] *)
 Section prod.

--- a/src/Rewriter/Util/Tactics/DebugPrint.v
+++ b/src/Rewriter/Util/Tactics/DebugPrint.v
@@ -13,21 +13,21 @@ Ltac solve_debugfail tac :=
 
 (** constr-based [idtac] *)
 Class cidtac {T} (msg : T) := Build_cidtac : True.
-Hint Extern 0 (cidtac ?msg) => idtac msg; exact I : typeclass_instances.
+#[global] Hint Extern 0 (cidtac ?msg) => idtac msg; exact I : typeclass_instances.
 (** constr-based [idtac] *)
 Class cidtac2 {T1 T2} (msg1 : T1) (msg2 : T2) := Build_cidtac2 : True.
-Hint Extern 0 (cidtac2 ?msg1 ?msg2) => idtac msg1 msg2; exact I : typeclass_instances.
+#[global] Hint Extern 0 (cidtac2 ?msg1 ?msg2) => idtac msg1 msg2; exact I : typeclass_instances.
 Class cidtac3 {T1 T2 T3} (msg1 : T1) (msg2 : T2) (msg3 : T3) := Build_cidtac3 : True.
-Hint Extern 0 (cidtac3 ?msg1 ?msg2 ?msg3) => idtac msg1 msg2 msg3; exact I : typeclass_instances.
+#[global] Hint Extern 0 (cidtac3 ?msg1 ?msg2 ?msg3) => idtac msg1 msg2 msg3; exact I : typeclass_instances.
 Class cidtac4 {T1 T2 T3 T4} (msg1 : T1) (msg2 : T2) (msg3 : T3) (msg4 : T4) := Build_cidtac4 : True.
-Hint Extern 0 (cidtac4 ?msg1 ?msg2 ?msg3 ?msg4) => idtac msg1 msg2 msg3 msg4; exact I : typeclass_instances.
+#[global] Hint Extern 0 (cidtac4 ?msg1 ?msg2 ?msg3 ?msg4) => idtac msg1 msg2 msg3 msg4; exact I : typeclass_instances.
 
 Class cfail {T} (msg : T) := Build_cfail : True.
-Hint Extern 0 (cfail ?msg) => idtac "Error:" msg; exact I : typeclass_instances.
+#[global] Hint Extern 0 (cfail ?msg) => idtac "Error:" msg; exact I : typeclass_instances.
 Class cfail2 {T1 T2} (msg1 : T1) (msg2 : T2) := Build_cfail2 : True.
-Hint Extern 0 (cfail2 ?msg1 ?msg2) => idtac "Error:" msg1 msg2; exact I : typeclass_instances.
+#[global] Hint Extern 0 (cfail2 ?msg1 ?msg2) => idtac "Error:" msg1 msg2; exact I : typeclass_instances.
 Class cfail3 {T1 T2 T3} (msg1 : T1) (msg2 : T2) (msg3 : T3) := Build_cfail3 : True.
-Hint Extern 0 (cfail3 ?msg1 ?msg2 ?msg3) => idtac "Error:" msg1 msg2 msg3; exact I : typeclass_instances.
+#[global] Hint Extern 0 (cfail3 ?msg1 ?msg2 ?msg3) => idtac "Error:" msg1 msg2 msg3; exact I : typeclass_instances.
 
 Ltac constr_run_tac tac :=
   let dummy := match goal with


### PR DESCRIPTION
This is mostly an adaptation for coq/coq#16004

We also make some other warnings into errors at the same time.