### PR TITLE
[Ltac2] [1/?] Move reification config to Ltac2

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -14,14 +14,8 @@ jobs:
     strategy:
       matrix:
         env:
-        - { COQ_VERSION: "8.14.0", COQ_PACKAGE: "coq-8.14.0 libcoq-8.14.0-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-08" }
-        - { COQ_VERSION: "8.13.2", COQ_PACKAGE: "coq-8.13.2 libcoq-8.13.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.12.2", COQ_PACKAGE: "coq-8.12.2 libcoq-8.12.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.11.2", COQ_PACKAGE: "coq-8.11.2 libcoq-8.11.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "v8.14" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.14-daily" }
-        - { COQ_VERSION: "v8.13" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.13-daily" }
-        - { COQ_VERSION: "v8.12" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.12-daily" }
-        - { COQ_VERSION: "v8.11" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.11-daily" }
+        - { COQ_VERSION: "8.15.0", COQ_PACKAGE: "coq-8.15.0 libcoq-8.15.0-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-08" }
+        - { COQ_VERSION: "v8.15" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.15-daily" }
 
     env: ${{ matrix.env }}
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Building
 -----
 [![CI (Coq)](https://github.com/mit-plv/rewriter/actions/workflows/coq.yml/badge.svg?branch=master)](https://github.com/mit-plv/rewriter/actions/workflows/coq.yml?query=branch%3Amaster)
 
-This repository requires Coq 8.11 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
+This repository requires Coq 8.15 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
 
 Git submodules are used for some dependencies. If you did not clone with `--recursive`, run
 

--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -107,6 +107,7 @@ src/Rewriter/Util/Tactics/Test.v
 src/Rewriter/Util/Tactics/TransparentAssert.v
 src/Rewriter/Util/Tactics/UniquePose.v
 src/Rewriter/Util/Tactics/WarnIfGoalsRemain.v
+src/Rewriter/Util/Tactics2/Head.v
 src/Rewriter/Util/plugins/RewriterBuildRegistryImports.v
 src/Rewriter/Util/plugins/definition_by_tactic.ml
 src/Rewriter/Util/plugins/definition_by_tactic.mli

--- a/src/Rewriter/Language/PreCommon.v
+++ b/src/Rewriter/Language/PreCommon.v
@@ -1,4 +1,5 @@
 (** Definitions used in rewrite rules and customizable tactics, which are invoked in the general rewriter framework. *)
+Require Import Ltac2.Init.
 Require Rewriter.Util.PrimitiveHList.
 Require Rewriter.Util.InductiveHList.
 Require Import Rewriter.Util.Notations.
@@ -10,12 +11,16 @@ Module Export Pre.
     Definition gets_inlined (real_val : bool) {T} (v : T) : bool := real_val.
   End ident.
 
+  (** These tactics should operate even on terms with unbound de
+      Bruijn indices.  Although we pass a list containing the types
+      and natural names of all unbound de Bruijn indices, this list
+      should ideally be unused, for performance reasons *)
   (** Modify this to get more match-to-elim conversion *)
-  Ltac reify_preprocess_extra term := term.
-  Ltac reify_ident_preprocess_extra term := term.
-  (** Change this with [Ltac reify_debug_level ::= constr:(1).] to get
-    more debugging. *)
-  Ltac reify_debug_level := constr:(0%nat).
+  Ltac2 mutable reify_preprocess_extra (ctx_tys : binder list) (term : constr) := term.
+  Ltac2 mutable reify_ident_preprocess_extra (ctx_tys : binder list) (term : constr) := term.
+  (** Change this with [Ltac2 Set reify_debug_level ::= 1.] to get
+      more debugging. *)
+  Ltac2 mutable reify_debug_level : int := 0.
 
   Module ScrapedData.
     Local Set Primitive Projections.

--- a/src/Rewriter/Language/Reify.v
+++ b/src/Rewriter/Language/Reify.v
@@ -326,11 +326,12 @@ Module Compilers.
                           end in
            (*let B := lazymatch type of b with forall x, @?B x => B end in*)
            reify_preprocess rec_val (*(@Let_In A B a b)*)
-      | ?term => reify_preprocess_extra term
+      | ?term => constr:(ltac:(let v := reify_preprocess_extra term in refine v))
       end.
 
     Ltac reify_ident_preprocess term :=
       let __ := Reify.debug_enter_reify_ident_preprocess term in
+      let reify_ident_preprocess_extra term := constr:(ltac:(let v := reify_ident_preprocess_extra term in refine v)) in
       lazymatch term with
       | Datatypes.S => reify_ident_preprocess Nat.succ
       | @Datatypes.prod_rect ?A ?B ?T0

--- a/src/Rewriter/Util/Tactics2/Head.v
+++ b/src/Rewriter/Util/Tactics2/Head.v
@@ -1,0 +1,13 @@
+Require Import Ltac2.Ltac2.
+Import Ltac2.Constr.Unsafe.
+Require Export Rewriter.Util.FixCoqMistakes.
+
+(** find the head of the given expression *)
+Ltac2 rec head (expr : constr) : constr :=
+  match kind expr with
+  | App f _ => f
+  | Cast c _ _ => head c
+  | _ => expr
+  end.
+
+Ltac2 head_hnf expr := let expr' := eval hnf in $expr in head expr'.


### PR DESCRIPTION
This is the first in a series of commits aimed at moving reification to Ltac2.

To make use of new Ltac2 features (like printf), we drop support for Coq < 8.15.  8.15 is present in Ubuntu LTS and Debian testing.

Here we just have some preliminaries.  Unfortunately, the overhead is quite painful already.

<details><summary>Timing Diff</summary>
<p>

```
   After |   Peak Mem | File Name                                                     |   Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
9m31.35s | 1608404 ko | Total Time / Peak Mem                                         | 8m50.30s | 1193572 ko || +0m41.04s ||    414832 ko |   +7.73% |        +34.75%
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
1m10.53s | 1608404 ko | Rewriter/Rewriter/Examples/PerfTesting/SieveOfEratosthenes.vo | 0m35.88s | 1081060 ko || +0m34.64s ||    527344 ko |  +96.57% |        +48.78%
0m29.03s |  943116 ko | Rewriter/Rewriter/Examples/PrefixSums.vo                      | 0m25.99s |  870536 ko || +0m03.04s ||     72580 ko |  +11.69% |         +8.33%
0m30.32s |  950820 ko | Rewriter/Rewriter/Examples.vo                                 | 0m28.62s |  898780 ko || +0m01.69s ||     52040 ko |   +5.93% |         +5.79%
1m50.38s | 1194492 ko | Rewriter/Rewriter/Wf.vo                                       | 1m50.16s | 1193572 ko || +0m00.21s ||       920 ko |   +0.19% |         +0.07%
0m59.60s |  727204 ko | Rewriter/Language/UnderLetsProofs.vo                          | 0m59.65s |  725804 ko || -0m00.04s ||      1400 ko |   -0.08% |         +0.19%
0m53.18s | 1103936 ko | Rewriter/Rewriter/Examples/PerfTesting/LiftLetsMap.vo         | 0m52.84s | 1072348 ko || +0m00.33s ||     31588 ko |   +0.64% |         +2.94%
0m52.12s |  941320 ko | Rewriter/Rewriter/InterpProofs.vo                             | 0m52.34s |  943380 ko || -0m00.22s ||     -2060 ko |   -0.42% |         -0.21%
0m48.43s |  789472 ko | Rewriter/Rewriter/ProofsCommon.vo                             | 0m48.43s |  792028 ko || +0m00.00s ||     -2556 ko |   +0.00% |         -0.32%
0m26.57s |  679460 ko | Rewriter/Language/Wf.vo                                       | 0m26.27s |  678124 ko || +0m00.30s ||      1336 ko |   +1.14% |         +0.19%
0m23.54s |  876944 ko | Rewriter/Rewriter/Examples/PerfTesting/Plus0Tree.vo           | 0m23.17s |  857244 ko || +0m00.36s ||     19700 ko |   +1.59% |         +2.29%
0m17.76s |  582400 ko | Rewriter/Language/Inversion.vo                                | 0m17.66s |  582420 ko || +0m00.10s ||       -20 ko |   +0.56% |         -0.00%
0m15.58s |  720812 ko | Rewriter/Rewriter/Examples/PerfTesting/UnderLetsPlus0.vo      | 0m15.07s |  707728 ko || +0m00.50s ||     13084 ko |   +3.38% |         +1.84%
0m11.72s |  637884 ko | Rewriter/Demo.vo                                              | 0m11.91s |  621920 ko || -0m00.18s ||     15964 ko |   -1.59% |         +2.56%
0m08.78s |  506124 ko | Rewriter/Language/IdentifiersLibraryProofs.vo                 | 0m08.66s |  502292 ko || +0m00.11s ||      3832 ko |   +1.38% |         +0.76%
0m04.18s |  468516 ko | Rewriter/Language/IdentifiersBasicLibrary.vo                  | 0m04.17s |  467052 ko || +0m00.00s ||      1464 ko |   +0.23% |         +0.31%
0m01.20s |  466280 ko | Rewriter/Language/IdentifiersLibrary.vo                       | 0m01.16s |  465112 ko || +0m00.04s ||      1168 ko |   +3.44% |         +0.25%
0m00.94s |  464796 ko | Rewriter/Rewriter/Rewriter.vo                                 | 0m01.02s |  462888 ko || -0m00.08s ||      1908 ko |   -7.84% |         +0.41%
0m00.89s |  444108 ko | Rewriter/Language/Language.vo                                 | 0m00.88s |  441940 ko || +0m00.01s ||      2168 ko |   +1.13% |         +0.49%
0m00.79s |  486056 ko | Rewriter/Rewriter/AllTactics.vo                               | 0m00.73s |  482704 ko || +0m00.06s ||      3352 ko |   +8.21% |         +0.69%
0m00.79s |  466732 ko | Rewriter/Rewriter/Reify.vo                                    | 0m00.87s |  463976 ko || -0m00.07s ||      2756 ko |   -9.19% |         +0.59%
0m00.65s |  470600 ko | Rewriter/Rewriter/ProofsCommonTactics.vo                      | 0m00.53s |  468832 ko || +0m00.12s ||      1768 ko |  +22.64% |         +0.37%
0m00.51s |  456184 ko | Rewriter/Language/IdentifiersGenerate.vo                      | 0m00.47s |  454428 ko || +0m00.04s ||      1756 ko |   +8.51% |         +0.38%
0m00.50s |  480024 ko | Rewriter/Rewriter/Examples/PerfTesting/Settings.vo            | 0m00.49s |  476252 ko || +0m00.01s ||      3772 ko |   +2.04% |         +0.79%
0m00.50s |  477392 ko | Rewriter/Util/plugins/RewriterBuildRegistryImports.vo         | 0m00.51s |  474300 ko || -0m00.01s ||      3092 ko |   -1.96% |         +0.65%
0m00.49s |  478308 ko | Rewriter/Util/plugins/RewriterBuildRegistry.vo                | 0m00.49s |  474464 ko || +0m00.00s ||      3844 ko |   +0.00% |         +0.81%
0m00.47s |  457216 ko | Rewriter/Language/IdentifiersGenerateProofs.vo                | 0m00.49s |  455532 ko || -0m00.02s ||      1684 ko |   -4.08% |         +0.36%
0m00.44s |  478304 ko | Rewriter/Util/plugins/RewriterBuild.vo                        | 0m00.45s |  474724 ko || -0m00.01s ||      3580 ko |   -2.22% |         +0.75%
0m00.40s |  439456 ko | Rewriter/Language/IdentifiersBasicGenerate.vo                 | 0m00.40s |  432956 ko || +0m00.00s ||      6500 ko |   +0.00% |         +1.50%
0m00.37s |  411880 ko | Rewriter/Language/Reify.vo                                    | 0m00.29s |  379640 ko || +0m00.08s ||     32240 ko |  +27.58% |         +8.49%
0m00.28s |  387020 ko | Rewriter/Language/UnderLets.vo                                | 0m00.29s |  384148 ko || -0m00.00s ||      2872 ko |   -3.44% |         +0.74%
0m00.26s |  307128 ko | Rewriter/Language/PreLemmas.vo                                | 0m00.27s |  304356 ko || -0m00.01s ||      2772 ko |   -3.70% |         +0.91%
0m00.09s |  114248 ko | Rewriter/Language/Pre.vo                                      | 0m00.08s |  111716 ko || +0m00.00s ||      2532 ko |  +12.49% |         +2.26%
0m00.06s |  112308 ko | Rewriter/Language/PreCommon.vo                                | 0m00.07s |  110924 ko || -0m00.01s ||      1384 ko |  -14.28% |         +1.24%

```
</p>
</details>