### PR TITLE
[Ltac2] [2/?] Move type reification to Ltac2

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -14,14 +14,8 @@ jobs:
     strategy:
       matrix:
         env:
-        - { COQ_VERSION: "8.14.0", COQ_PACKAGE: "coq-8.14.0 libcoq-8.14.0-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-08" }
-        - { COQ_VERSION: "8.13.2", COQ_PACKAGE: "coq-8.13.2 libcoq-8.13.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.12.2", COQ_PACKAGE: "coq-8.12.2 libcoq-8.12.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.11.2", COQ_PACKAGE: "coq-8.11.2 libcoq-8.11.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "v8.14" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.14-daily" }
-        - { COQ_VERSION: "v8.13" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.13-daily" }
-        - { COQ_VERSION: "v8.12" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.12-daily" }
-        - { COQ_VERSION: "v8.11" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.11-daily" }
+        - { COQ_VERSION: "8.15.0", COQ_PACKAGE: "coq-8.15.0 libcoq-8.15.0-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-08" }
+        - { COQ_VERSION: "v8.15" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.15-daily" }
 
     env: ${{ matrix.env }}
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Building
 -----
 [![CI (Coq)](https://github.com/mit-plv/rewriter/actions/workflows/coq.yml/badge.svg?branch=master)](https://github.com/mit-plv/rewriter/actions/workflows/coq.yml?query=branch%3Amaster)
 
-This repository requires Coq 8.11 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
+This repository requires Coq 8.15 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
 
 Git submodules are used for some dependencies. If you did not clone with `--recursive`, run
 

--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -107,6 +107,7 @@ src/Rewriter/Util/Tactics/Test.v
 src/Rewriter/Util/Tactics/TransparentAssert.v
 src/Rewriter/Util/Tactics/UniquePose.v
 src/Rewriter/Util/Tactics/WarnIfGoalsRemain.v
+src/Rewriter/Util/Tactics2/Head.v
 src/Rewriter/Util/plugins/RewriterBuildRegistryImports.v
 src/Rewriter/Util/plugins/definition_by_tactic.ml
 src/Rewriter/Util/plugins/definition_by_tactic.mli

--- a/src/Rewriter/Language/IdentifiersBasicGenerate.v
+++ b/src/Rewriter/Language/IdentifiersBasicGenerate.v
@@ -488,11 +488,19 @@ Module Compilers.
       Ltac make_base_type_list base_type_list_named :=
         let res := build_base_type_list base_type_list_named in refine res.
 
+      (* TODO MOVE to util *)
+      Ltac2 eval_cbv_beta (c : constr) :=
+        Std.eval_cbv { Std.rBeta := true; Std.rMatch := false;
+                       Std.rFix := false; Std.rCofix := false;
+                       Std.rZeta := false; Std.rDelta := false;
+                       Std.rConst := [] }
+                     c.
+
       Ltac2 reify_base_via_list_opt (base : constr) (base_interp : constr) (all_base_and_interp : constr) :=
-        let all_base_and_interp := (eval hnf in $all_base_and_interp) in
-        let all_base_and_interp := (eval cbv beta in $all_base_and_interp) in
+        let all_base_and_interp := Std.eval_hnf all_base_and_interp in
+        let all_base_and_interp := eval_cbv_beta all_base_and_interp in
         fun ty
-        => let ty := (eval cbv beta in $ty) in
+        => let ty := eval_cbv_beta ty in
            Reify.debug_enter_reify "reify_base_via_list" ty;
            let rty := match! all_base_and_interp with
                       | context[Datatypes.cons (?rty, ?ty')]

--- a/src/Rewriter/Language/IdentifiersBasicGenerate.v
+++ b/src/Rewriter/Language/IdentifiersBasicGenerate.v
@@ -485,7 +485,7 @@ Module Compilers.
       Ltac make_base_type_list base_type_list_named :=
         let res := build_base_type_list base_type_list_named in refine res.
 
-      Ltac reify_base_via_list base base_interp all_base_and_interp :=
+      Ltac reify_base_via_list_internal base base_interp all_base_and_interp :=
         let all_base_and_interp := (eval hnf in all_base_and_interp) in
         let all_base_and_interp := (eval cbv beta in all_base_and_interp) in
         fun ty
@@ -501,6 +501,8 @@ Module Compilers.
                 | _ => constr_fail_with ltac:(fun _ => fail 1 "Unrecognized type:" ty)
                 end
            end.
+      Ltac reify_base_via_list base base_interp all_base_and_interp ty :=
+        constr:(ltac:(let v := reify_base_via_list_internal base base_interp all_base_and_interp ty in refine v)).
 
       Ltac reify_base_type_via_list base base_interp all_base_and_interp :=
         Compilers.base.reify base ltac:(reify_base_via_list base base_interp all_base_and_interp).

--- a/src/Rewriter/Language/PreCommon.v
+++ b/src/Rewriter/Language/PreCommon.v
@@ -1,4 +1,5 @@
 (** Definitions used in rewrite rules and customizable tactics, which are invoked in the general rewriter framework. *)
+Require Import Ltac2.Init.
 Require Rewriter.Util.PrimitiveHList.
 Require Rewriter.Util.InductiveHList.
 Require Import Rewriter.Util.Notations.
@@ -10,12 +11,16 @@ Module Export Pre.
     Definition gets_inlined (real_val : bool) {T} (v : T) : bool := real_val.
   End ident.
 
+  (** These tactics should operate even on terms with unbound de
+      Bruijn indices.  Although we pass a list containing the types
+      and natural names of all unbound de Bruijn indices, this list
+      should ideally be unused, for performance reasons *)
   (** Modify this to get more match-to-elim conversion *)
-  Ltac reify_preprocess_extra term := term.
-  Ltac reify_ident_preprocess_extra term := term.
-  (** Change this with [Ltac reify_debug_level ::= constr:(1).] to get
-    more debugging. *)
-  Ltac reify_debug_level := constr:(0%nat).
+  Ltac2 mutable reify_preprocess_extra (ctx_tys : binder list) (term : constr) := term.
+  Ltac2 mutable reify_ident_preprocess_extra (ctx_tys : binder list) (term : constr) := term.
+  (** Change this with [Ltac2 Set reify_debug_level ::= 1.] to get
+      more debugging. *)
+  Ltac2 mutable reify_debug_level : int := 0.
 
   Module ScrapedData.
     Local Set Primitive Projections.

--- a/src/Rewriter/Language/Reify.v
+++ b/src/Rewriter/Language/Reify.v
@@ -326,11 +326,12 @@ Module Compilers.
                           end in
            (*let B := lazymatch type of b with forall x, @?B x => B end in*)
            reify_preprocess rec_val (*(@Let_In A B a b)*)
-      | ?term => reify_preprocess_extra term
+      | ?term => constr:(ltac:(let v := reify_preprocess_extra term in refine v))
       end.
 
     Ltac reify_ident_preprocess term :=
       let __ := Reify.debug_enter_reify_ident_preprocess term in
+      let reify_ident_preprocess_extra term := constr:(ltac:(let v := reify_ident_preprocess_extra term in refine v)) in
       lazymatch term with
       | Datatypes.S => reify_ident_preprocess Nat.succ
       | @Datatypes.prod_rect ?A ?B ?T0

--- a/src/Rewriter/Util/Tactics2/Head.v
+++ b/src/Rewriter/Util/Tactics2/Head.v
@@ -1,0 +1,13 @@
+Require Import Ltac2.Ltac2.
+Import Ltac2.Constr.Unsafe.
+Require Export Rewriter.Util.FixCoqMistakes.
+
+(** find the head of the given expression *)
+Ltac2 rec head (expr : constr) : constr :=
+  match kind expr with
+  | App f _ => f
+  | Cast c _ _ => head c
+  | _ => expr
+  end.
+
+Ltac2 head_hnf expr := let expr' := eval hnf in $expr in head expr'.


### PR DESCRIPTION
<details><summary>Timing Diff</summary>
<p>

```
   After |   Peak Mem | File Name                                                     |   Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
4m01.25s | 1594616 ko | Total Time / Peak Mem                                         | 4m02.25s | 1614532 ko || -0m01.00s ||    -19916 ko |   -0.41% |         -1.23%
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
1m10.55s | 1594616 ko | Rewriter/Rewriter/Examples/PerfTesting/SieveOfEratosthenes.vo | 1m10.96s | 1614532 ko || -0m00.41s ||    -19916 ko |   -0.57% |         -1.23%
0m54.70s | 1105728 ko | Rewriter/Rewriter/Examples/PerfTesting/LiftLetsMap.vo         | 0m54.89s | 1110312 ko || -0m00.18s ||     -4584 ko |   -0.34% |         -0.41%
0m31.04s |  965772 ko | Rewriter/Rewriter/Examples.vo                                 | 0m30.78s |  963144 ko || +0m00.25s ||      2628 ko |   +0.84% |         +0.27%
0m29.00s |  957384 ko | Rewriter/Rewriter/Examples/PrefixSums.vo                      | 0m29.60s |  964552 ko || -0m00.60s ||     -7168 ko |   -2.02% |         -0.74%
0m23.90s |  882380 ko | Rewriter/Rewriter/Examples/PerfTesting/Plus0Tree.vo           | 0m23.73s |  889816 ko || +0m00.16s ||     -7436 ko |   +0.71% |         -0.83%
0m15.70s |  738120 ko | Rewriter/Rewriter/Examples/PerfTesting/UnderLetsPlus0.vo      | 0m15.76s |  742336 ko || -0m00.06s ||     -4216 ko |   -0.38% |         -0.56%
0m12.05s |  646124 ko | Rewriter/Demo.vo                                              | 0m12.04s |  642644 ko || +0m00.01s ||      3480 ko |   +0.08% |         +0.54%
0m00.79s |  466720 ko | Rewriter/Rewriter/Reify.vo                                    | 0m00.87s |  466888 ko || -0m00.07s ||      -168 ko |   -9.19% |         -0.03%
0m00.71s |  486128 ko | Rewriter/Rewriter/AllTactics.vo                               | 0m00.78s |  486088 ko || -0m00.07s ||        40 ko |   -8.97% |         +0.00%
0m00.55s |  479740 ko | Rewriter/Rewriter/Examples/PerfTesting/Settings.vo            | 0m00.52s |  479976 ko || +0m00.03s ||      -236 ko |   +5.76% |         -0.04%
0m00.52s |  477504 ko | Rewriter/Util/plugins/RewriterBuildRegistryImports.vo         | 0m00.55s |  477340 ko || -0m00.03s ||       164 ko |   -5.45% |         +0.03%
0m00.51s |  477964 ko | Rewriter/Util/plugins/RewriterBuild.vo                        | 0m00.51s |  478308 ko || +0m00.00s ||      -344 ko |   +0.00% |         -0.07%
0m00.49s |  477988 ko | Rewriter/Util/plugins/RewriterBuildRegistry.vo                | 0m00.50s |  478396 ko || -0m00.01s ||      -408 ko |   -2.00% |         -0.08%
0m00.40s |  439224 ko | Rewriter/Language/IdentifiersBasicGenerate.vo                 | 0m00.42s |  439304 ko || -0m00.01s ||       -80 ko |   -4.76% |         -0.01%
0m00.34s |  411992 ko | Rewriter/Language/Reify.vo                                    | 0m00.34s |  412596 ko || +0m00.00s ||      -604 ko |   +0.00% |         -0.14%

```
</p>
</details>