### PR TITLE
Adapt w.r.t. coq/coq#16910.

### DIFF
--- a/src/Rewriter/Util/ListUtil.v
+++ b/src/Rewriter/Util/ListUtil.v
@@ -1399,7 +1399,7 @@ Proof.
           | Some v => fun _ => v
           | None => fun bad => match _ : False with end
           end eq_refl).
-  apply (proj1 (@nth_error_None _ _ _)) in bad; instantiate; generalize dependent (length ls); clear.
+  apply (proj1 (@nth_error_None _ _ _)) in bad; generalize dependent (length ls); clear.
   abstract (intros; lia).
 Defined.
 


### PR DESCRIPTION
The instantiate tactic was an explicit no-op since 8.16, and also in practice since the progressive move to EConstr. Not sure up to which version you want Rewriter to work, but this should go quite far back.