### PR TITLE
Adapt to coq/coq#18197 (List and Array fold argument order change)

### DIFF
--- a/src/Rewriter/Rewriter/Reify.v
+++ b/src/Rewriter/Rewriter/Reify.v
@@ -25,6 +25,7 @@ Require Import Rewriter.Util.Tactics.CacheTerm.
 Require Import Rewriter.Util.Tactics.DebugPrint.
 Require Import Rewriter.Util.CPSNotations.
 Require Import Rewriter.Util.Notations.
+Require Rewriter.Util.Tactics2.List.
 Require Import Rewriter.Util.Tactics2.Head.
 Require Import Rewriter.Util.Tactics2.HeadReference.
 Require Import Rewriter.Util.Tactics2.Constr.Unsafe.MakeAbbreviations.
@@ -416,7 +417,7 @@ Module Compilers.
                         (fprintf
                            "Invalid (in %t):%s%a"
                            term (String.newline ())
-                           (fun ()
+                           (fun () x
                             => List.fold_right
                                  (fun (argn, msg) rest
                                   => (fprintf "Invalid (arg %i): %a%s%a"
@@ -424,6 +425,7 @@ Module Compilers.
                                               (fun () x => x) msg
                                               (String.newline ())
                                               (fun () x => x) rest))
+                                 x
                                  (Message.of_string ""))
                            (v :: vs)))
               end).

--- a/src/Rewriter/Util/Tactics2/List.v
+++ b/src/Rewriter/Util/Tactics2/List.v
@@ -21,3 +21,17 @@ Ltac2 rec for_all2_aux (on_length_mismatch : 'a list -> 'b list -> bool) f xs ys
 
 (* Drop once the minimum dependency has been bumpped to 8.17 *)
 Ltac2 equal f xs ys := for_all2_aux (fun _ _ => false) f xs ys.
+
+(* Drop once the minimum dependency has been bumpped to 8.19 *)
+Ltac2 rec fold_right (f : 'a -> 'b -> 'b) (ls : 'a list) (a : 'b) : 'b :=
+  match ls with
+  | [] => a
+  | l :: ls => f l (fold_right f ls a)
+  end.
+
+(* Drop once the minimum dependency has been bumpped to 8.19 *)
+Ltac2 rec fold_left (f : 'a -> 'b -> 'a) (a : 'a) (xs : 'b list) : 'a :=
+  match xs with
+  | [] => a
+  | x :: xs => fold_left f (f a x) xs
+  end.

--- a/src/Rewriter/Util/Tactics2/Message.v
+++ b/src/Rewriter/Util/Tactics2/Message.v
@@ -1,6 +1,7 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Printf.
 Require Export Rewriter.Util.FixCoqMistakes.
+Require Rewriter.Util.Tactics2.List.
 
 Ltac2 of_list (pr : 'a -> message) (ls : 'a list) : message
   := fprintf
@@ -9,7 +10,7 @@ Ltac2 of_list (pr : 'a -> message) (ls : 'a list) : message
        (match ls with
         | [] => fprintf ""
         | x :: xs
-          => List.fold_left (fun init x => fprintf "%a, %a" (fun () a => a) init (fun () => pr) x) xs (pr x)
+          => List.fold_left (fun init x => fprintf "%a, %a" (fun () a => a) init (fun () => pr) x) (pr x) xs
         end).
 
 Ltac2 of_binder (b : binder) : message


### PR DESCRIPTION
Should be backwards compatible (by vendoring the new definition until backward compat is dropped)