### PR TITLE
Add profiling for cbn

### DIFF
--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coq-version: [ '8.16' ]
-        extra-gh-reportify: [ '' ]
+        #coq-version: [ '8.16' ]
+        #extra-gh-reportify: [ '' ]
         include:
         - coq-version: 'dev'
           extra-gh-reportify: '--warnings'

--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -20,16 +20,9 @@ jobs:
         env:
          - { COQ_VERSION: "8.18.0", COQ_PACKAGE: "coq-8.18.0 libcoq-8.18.0-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-11" }
          - { COQ_VERSION: "8.17.1", COQ_PACKAGE: "coq-8.17.1 libcoq-8.17.1-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-11" }
-         # Ltac2 is broken in the 8.16 package
-         #- { COQ_VERSION: "8.16.1", COQ_PACKAGE: "coq-8.16.1 libcoq-8.16.1-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-11" }
-         - { COQ_VERSION: "8.15.2", COQ_PACKAGE: "coq-8.15.2 libcoq-8.15.2-ocaml-dev", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-08" }
-        os: [ ubuntu-latest ]
-        include:
-        - env: { COQ_VERSION: "v8.15" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.15-daily" }
-          os: ubuntu-20.04
 
     env: ${{ matrix.env }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.env.COQ_VERSION }}-${{ github.head_ref || github.run_id }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Publications
 
 Building
 -----
-This repository requires Coq 8.15 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
+This repository requires Coq 8.17 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
 
 Git submodules are used for some dependencies. If you did not clone with `--recursive`, run
 

--- a/src/Rewriter/Language/PreCommon.v
+++ b/src/Rewriter/Language/PreCommon.v
@@ -21,6 +21,7 @@ Module Export Pre.
   (** Change this with [Ltac2 Set reify_debug_level ::= 1.] to get
       more debugging. *)
   Ltac2 mutable reify_debug_level : int := 0.
+  Ltac2 mutable reify_profile_cbn : bool := false.
 
   Module ScrapedData.
     Local Set Primitive Projections.


### PR DESCRIPTION
Seems to be responsible for 23.0% of the cost of rewrite rules in https://github.com/mit-plv/fiat-crypto/pull/1778, with a single call taking 168.429s.

Should not add much overhead (just a branch) when not enabled.