### PR TITLE
Adapt to coq#19822

### DIFF
--- a/src/Rewriter/Rewriter/ProofsCommon.v
+++ b/src/Rewriter/Rewriter/ProofsCommon.v
@@ -3674,7 +3674,7 @@ Module Compilers.
                            [ now eauto | intros | reflexivity ];
                            try solve [ fin_t ]
                          | progress (cbn [UnderLets.interp_related UnderLets.interp_related_gen expr.interp_related expr.interp_related_gen];
-                                     repeat (eexists; [> idtac ]; eexists; repeat apply conj; intros))
+                                     repeat (eexists; []; eexists; repeat apply conj; intros))
                          | solve
                              [ repeat
                                  first

--- a/src/Rewriter/Rewriter/ProofsCommon.v
+++ b/src/Rewriter/Rewriter/ProofsCommon.v
@@ -3674,7 +3674,7 @@ Module Compilers.
                            [ now eauto | intros | reflexivity ];
                            try solve [ fin_t ]
                          | progress (cbn [UnderLets.interp_related UnderLets.interp_related_gen expr.interp_related expr.interp_related_gen];
-                                     repeat (do 2 eexists; repeat apply conj; intros))
+                                     repeat (eexists; [> idtac ]; eexists; repeat apply conj; intros))
                          | solve
                              [ repeat
                                  first


### PR DESCRIPTION
https://github.com/coq/coq/pull/19822 strengthens the unification algorithm, which now allows `eexists` to solve more goals than before, so we need to restrict it a bit.