### PR TITLE
Adapt to https://github.com/rocq-prover/rocq/pull/21849

### DIFF
--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coq-version: [ '8.18', '8.19', '8.20' , '9.0' , '9.1' ]
+        coq-version: [ '8.19', '8.20' , '9.0' , '9.1' ]
         extra-gh-reportify: [ '' ]
         skip-validate: [ '' ]
         include:

--- a/.github/workflows/coq-opam-package.yml
+++ b/.github/workflows/coq-opam-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coq-version: ['dev', '8.20.0', '8.19.0', '8.18.0' , '9.0.0' , '9.1.0' ]
+        coq-version: ['dev', '8.20.0', '8.19.0', '9.0.0' , '9.1.0' ]
         os: [{name: 'Ubuntu',
               runs-on: 'ubuntu-latest',
               ocaml-compiler: '4.14.0',

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Publications
 
 Building
 -----
-This repository requires Coq 8.18 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
+This repository requires Coq 8.19 or later, and requires that the version of OCaml used to build Coq be installed and accessible on the system.
 
 Git submodules are used for some dependencies. If you did not clone with `--recursive`, run
 

--- a/coq-rewriter.opam
+++ b/coq-rewriter.opam
@@ -16,7 +16,7 @@ install: [make "install"]
 depends: [
   "conf-findutils" {build}
   "ocaml" {build & (arch = "x86_32" | arch = "x86_64" | >= "4.14.0")}
-  "coq" {>= "8.18~"}
+  "coq" {>= "8.19~"}
 ]
 dev-repo: "git+https://github.com/mit-plv/rewriter.git"
 synopsis: "Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting, experimental and tailored for use in Fiat Cryptography"

--- a/src/Rewriter/Language/Language.v
+++ b/src/Rewriter/Language/Language.v
@@ -296,7 +296,7 @@ Module Compilers.
   Declare Scope etype_scope.
   Delimit Scope etype_scope with etype.
   Bind Scope etype_scope with type.type.
-  Global Arguments type.base {_} _%etype.
+  Global Arguments type.base {_} _%_etype.
   Infix "->" := type.arrow : etype_scope.
   Infix "==" := type.eqv : type_scope.
   Module base.
@@ -911,7 +911,7 @@ Module Compilers.
     Module Export Notations.
       Declare Scope ident_scope.
       Delimit Scope ident_scope with ident.
-      Global Arguments expr.Ident {base_type%type ident%function var%function t%etype} idc%ident.
+      Global Arguments expr.Ident {base_type%_type ident%_function var%_function t%_etype} idc%_ident.
       Notation "# x" := (expr.Ident x) (only parsing) : expr_pat_scope.
       Notation "# x" := (@expr.Ident _ _ _ _ x) : expr_scope.
       Notation "x @ y" := (expr.App x%expr_pat y%expr_pat) (only parsing) : expr_pat_scope.

--- a/src/Rewriter/Rewriter/Rewriter.v
+++ b/src/Rewriter/Rewriter/Rewriter.v
@@ -358,7 +358,7 @@ Module Compilers.
       | App (f x : pattern).
     End Raw.
 
-    Global Arguments Wildcard {base ident}%type t%ptype.
+    Global Arguments Wildcard {base ident}%_type t%_ptype.
 
     Fixpoint to_raw {base ident raw_ident}
              {to_raw_ident : forall t, ident t -> raw_ident}

--- a/src/Rewriter/Util/Decidable.v
+++ b/src/Rewriter/Util/Decidable.v
@@ -11,7 +11,7 @@ From Coq Require Import BinNat.
 Local Open Scope type_scope.
 
 Class Decidable (P : Prop) := dec : {P} + {~P}.
-Arguments dec _%type_scope {_}.
+Arguments dec _%_type_scope {_}.
 Notation DecidableRel R := (forall x y, Decidable (R x y)).
 
 Global Instance hprop_eq_dec {A} `{DecidableRel (@eq A)} : IsHPropRel (@eq A) | 10.


### PR DESCRIPTION
Adapt to https://github.com/rocq-prover/rocq/pull/21849

This should be backward compatible (down to 8.19) and can be merged now.