### PR TITLE
describe-system-config: also query the rocq-runtime findlib packages

### DIFF
--- a/etc/ci/describe-system-config.sh
+++ b/etc/ci/describe-system-config.sh
@@ -49,6 +49,9 @@ group ocamlfind query coq
 group ocamlfind query coq-core
 group ocamlfind query coq-core.plugins
 group ocamlfind query coq-core.plugins.ltac
+group ocamlfind query rocq-runtime
+group ocamlfind query rocq-runtime.plugins
+group ocamlfind query rocq-runtime.plugins.ltac
 group "ocamlfind query coq | xargs find"
 group coqc --config
 group coqc --version


### PR DESCRIPTION
The diagnostic script only queried coq-core.* findlib packages. Since Rocq 9.0 the plugins live under rocq-runtime.* (coq-core.* were compat aliases, removed in https://github.com/rocq-prover/rocq/pull/21955), so on Rocq 9.x the coq-core queries now report "not found" while the real rocq-runtime packages go unreported. Query both so the system-config log is useful for diagnosing findlib resolution failures (such as the coq-core.plugins.ltac-not-found error) on both Coq 8.x and Rocq 9.x.

https://claude.ai/code/session_01PjCbMk9zjAZWvZHuznFXqh