### PR TITLE
[CI] Add a debian-sid job; pick the findlib plugin prefix by probing

### DIFF
--- a/.github/workflows/coq-debian.yml
+++ b/.github/workflows/coq-debian.yml
@@ -1,0 +1,60 @@
+name: CI (Coq, Debian)
+
+on:
+  push:
+    branches: [ master , debian-testing ]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+  release:
+    types: [published]
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - debian: 'sid'
+
+    runs-on: ubuntu-latest
+    name: debian-${{ matrix.debian }}
+    container: debian:${{ matrix.debian }}
+
+    concurrency:
+      group: ${{ github.workflow }}-debian-${{ matrix.debian }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
+    steps:
+    - name: install system dependencies
+      run: |
+        apt-get -o Acquire::Retries=30 update -y
+        apt-get -q -y --allow-unauthenticated -o Acquire::Retries=30 install git make time jq python3 python-is-python3 ocaml coq libcoq-core-ocaml-dev libfindlib-ocaml-dev ocaml-findlib
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - name: work around broken git config
+      run: git config --global --add safe.directory "*"
+    - name: container build params
+      run: etc/ci/describe-system-config.sh
+    - name: make all
+      run: etc/ci/github-actions-make.sh ALLOW_DIFF=1 -j2 all
+    - name: make perf-Sanity
+      run: etc/ci/github-actions-make.sh ALLOW_DIFF=1 -j2 perf-Sanity
+    - name: display timing info
+      run: cat time-of-build-pretty.log
+    - name: display per-line timing info
+      run: etc/ci/github-actions-display-per-line-timing.sh
+
+  debian-check-all:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: always()
+    steps:
+    - run: echo 'build passed'
+      if: ${{ needs.build.result == 'success' }}
+    - run: echo 'build failed' && false
+      if: ${{ needs.build.result != 'success' }}

--- a/.github/workflows/coq-debian.yml
+++ b/.github/workflows/coq-debian.yml
@@ -32,7 +32,7 @@ jobs:
     - name: install system dependencies
       run: |
         apt-get -o Acquire::Retries=30 update -y
-        apt-get -q -y --allow-unauthenticated -o Acquire::Retries=30 install git make time jq python3 python-is-python3 ocaml coq libcoq-core-ocaml-dev libfindlib-ocaml-dev ocaml-findlib
+        apt-get -q -y --allow-unauthenticated -o Acquire::Retries=30 install git make time jq python3 python-is-python3 ocaml coq libcoq-stdlib libcoq-core-ocaml-dev libfindlib-ocaml-dev ocaml-findlib
     - uses: actions/checkout@v6
       with:
         submodules: recursive

--- a/Makefile.local-late
+++ b/Makefile.local-late
@@ -4,9 +4,19 @@ include Makefile.local.common
 
 $(VOFILES) $(CMOFILES) $(CMXFILES) $(OFILES) $(CMAFILES) $(CMIFILES) $(CMXSFILES): $(COQ_VERSION_FILE)
 
-$(COMPATIBILITY_FILES) : % : %$(EXPECTED_EXT) $(COQ_VERSION_FILE)
+META_FILE := src/Rewriter/Util/plugins/META.coq-rewriter
+
+$(filter-out $(META_FILE),$(COMPATIBILITY_FILES)) : % : %$(EXPECTED_EXT) $(COQ_VERSION_FILE)
 	$(SHOW)'CP $@{$(EXPECTED_EXT),}'
 	$(HIDE)cp $< $@
+
+# The checked-in META files spell the findlib prefix that goes with their Rocq
+# version; rewrite it to the one that actually resolves here (see
+# COQ_PLUGIN_PKG_PREFIX in Makefile.local.common).  On installations where the
+# guess was already right this is a no-op.
+$(META_FILE) : % : %$(EXPECTED_EXT) $(COQ_VERSION_FILE)
+	$(SHOW)'CP $@{$(EXPECTED_EXT),} ($(COQ_PLUGIN_PKG_PREFIX).plugins)'
+	$(HIDE)sed -E 's/(coq-core|rocq-runtime)\.plugins/$(COQ_PLUGIN_PKG_PREFIX).plugins/g' $< > $@
 
 # ensure that the ml compat files exist before we call coqdep on the corresponding .v files
 $(ALLDFILES): $(COMPATIBILITY_FILES) $(COQ_VERSION_FILE) _CoqProject
@@ -17,8 +27,4 @@ OTHERFLAGS += -profile-ltac
 endif
 
 # Kludge around COQBUG(https://github.com/coq/coq/issues/16591)
-ifneq (,$(filter .v815 .v816 .v817 .v818 .v819 .v820 .v821 .v90 .v91 .v92,$(EXPECTED_EXT)))
-FINDLIBPKGS += -package coq-core.plugins.ltac2
-else
-FINDLIBPKGS += -package rocq-runtime.plugins.ltac2
-endif
+FINDLIBPKGS += -package $(COQ_PLUGIN_PKG_PREFIX).plugins.ltac2

--- a/Makefile.local.common
+++ b/Makefile.local.common
@@ -89,6 +89,33 @@ endif
 endif
 endif
 
+# Rocq exposes its plugins to findlib under coq-core.plugins.* up to 9.2 and
+# under rocq-runtime.plugins.* from 9.3 on, so the version we selected above
+# normally determines the right prefix.  That correspondence is a property of
+# the *packaging*, not of the Rocq version: Debian's rocq 9.2 registers only the
+# rocq-runtime.* names (its coq-core META covers coq-core.kernel alone), so the
+# version-derived guess does not resolve there.  Ask ocamlfind, and keep the
+# version-derived answer whenever it works or whenever ocamlfind is unavailable,
+# so this can only ever turn a failing build into a working one.
+ifeq (,$(COQ_PLUGIN_PKG_PREFIX))
+OCAMLFIND?=ocamlfind
+ifneq (,$(filter .v815 .v816 .v817 .v818 .v819 .v820 .v821 .v90 .v91 .v92,$(EXPECTED_EXT)))
+COQ_PLUGIN_PKG_PREFIX_DEFAULT := coq-core
+else
+COQ_PLUGIN_PKG_PREFIX_DEFAULT := rocq-runtime
+endif
+COQ_PLUGIN_PKG_PREFIX := $(shell \
+	if $(OCAMLFIND) query $(COQ_PLUGIN_PKG_PREFIX_DEFAULT).plugins.ltac2 >/dev/null 2>&1; then \
+		echo $(COQ_PLUGIN_PKG_PREFIX_DEFAULT); \
+	elif $(OCAMLFIND) query rocq-runtime.plugins.ltac2 >/dev/null 2>&1; then \
+		echo rocq-runtime; \
+	elif $(OCAMLFIND) query coq-core.plugins.ltac2 >/dev/null 2>&1; then \
+		echo coq-core; \
+	else \
+		echo $(COQ_PLUGIN_PKG_PREFIX_DEFAULT); \
+	fi)
+endif
+
 COMPATIBILITY_FILES := \
 	src/Rewriter/Util/plugins/META.coq-rewriter \
 	src/Rewriter/Util/plugins/definition_by_tactic.ml \


### PR DESCRIPTION
Adds a `debian-sid` CI job modeled on fiat-crypto's [`coq-debian.yml`](https://github.com/mit-plv/fiat-crypto/blob/master/.github/workflows/coq-debian.yml), and fixes the build failure it exposes.

### The failure

fiat-crypto's debian-sid job currently dies building rewriter ([run 30394645647](https://github.com/mit-plv/fiat-crypto/actions/runs/30394645647/job/90394447712?pr=2367#step:7:2648)):

```
*** Error: In file src/Rewriter/Util/plugins/Ltac2Extra.v
           findlib error: coq-core.plugins.ltac2 not found in:
           src/Rewriter/Util/plugins
           /usr/lib/x86_64-linux-gnu/ocaml/5.4.1/coq/../rocq-runtime/..
           ...
           required by `coq-rewriter.ltac2_extra'
```

Debian sid ships `libcoq-core-ocaml-dev` 9.2.0+dfsg-3+b1, so `Makefile.local.common` picks `EXPECTED_EXT=.v92` and copies `META.coq-rewriter.v92`, which requires `coq-core.plugins.ltac` / `coq-core.plugins.ltac2`. Debian registers those plugins under `rocq-runtime.plugins.*`; its `coq-core` META covers `coq-core.kernel` and nothing else. `ocamlfind list` in that job:

```
coq-core            (version: n/a)
coq-core.kernel     (version: dev)
rocq-runtime.plugins.ltac  (version: dev)
rocq-runtime.plugins.ltac2 (version: dev)
```

### The fix

Which prefix is right is a property of the *packaging*, not of the Rocq version — opam's 9.2 registers both spellings, Debian's registers only one. So probe with `ocamlfind` rather than deriving it from the version.

`COQ_PLUGIN_PKG_PREFIX` starts from the version-derived answer and keeps it whenever it resolves, or whenever `ocamlfind` is unavailable; it only falls back to the other spelling when the first one is genuinely absent. That makes the change unable to turn a working build into a failing one.

The generated `META.coq-rewriter` is now rewritten through that prefix instead of copied verbatim, and `FINDLIBPKGS` uses it directly (replacing the duplicated version list in `Makefile.local-late`).

### Verification

Against the `rocq-9.2` opam switch (9.2+rc2), using a stub `ocamlfind` that fails `query coq-core.plugins.*` and delegates everything else, to simulate Debian:

| switch | ocamlfind | generated META |
|---|---|---|
| rocq-9.2 | real | `coq-core.plugins.*` — unchanged |
| rocq-9.2 | Debian-like stub | `rocq-runtime.plugins.*` |
| rocq-dev (9.4, `.v93`) | real | `rocq-runtime.plugins.*` — unchanged |

In the middle row the generated file is **byte-identical to the checked-in `META.coq-rewriter.v93`**. In the first row `make src/Rewriter/Util/plugins/Ltac2Extra.vo` is green (rc=0), i.e. the real `coq-core` path still builds.

The stub can only affect the makefile's own queries, so the Debian path itself is what this PR's new CI job is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b